### PR TITLE
removed SkipOsShutdown and Force flags

### DIFF
--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -138,7 +138,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             for env in environments.values():
                 if isinstance(env, Ec2SandboxEnvironment):
                     env.ec2_client.terminate_instances(
-                        InstanceIds=[env.instance_id], SkipOsShutdown=True, Force=True
+                        InstanceIds=[env.instance_id]
                     )
         return None
 
@@ -248,9 +248,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
                 instance_ids = []
                 for instance in instances:
                     instance_ids.append(instance["InstanceId"])
-                ec2.terminate_instances(
-                    InstanceIds=list(instance_ids), SkipOsShutdown=True, Force=True
-                )
+                ec2.terminate_instances(InstanceIds=list(instance_ids))
 
             else:
                 print("\nNo EC2 sandbox instances found to clean up.\n")


### PR DESCRIPTION
Removed SkipOsShutdown=True, Force=True flags when calling ec2_client.terminate_instances() to fix this error when running on t2 instances...

ClientError: An error occurred (OperationNotPermitted) when calling the
  TerminateInstances operation: SkipOsShutdown is not supported on Xen instance types.

I couldn't find any docs from AWS saying that these flags weren't supported on some instance types but the error msg is pretty clear.

Ran tests afterwards.