### PR TITLE
Add Ec2InstanceProvider hook for pluggable instance lifecycle

### DIFF
--- a/infra/ec2sandboxinfra/ec2sandbox_stack.py
+++ b/infra/ec2sandboxinfra/ec2sandbox_stack.py
@@ -129,18 +129,32 @@ class Ec2SandboxStack(cdk.Stack):
             ],
         )
 
-        # S3 permissions for file operations
+        # S3 permissions for sandbox instances.  Sandboxes only need PutObject
+        # (SSM agent uploads command stdout/stderr via OutputS3BucketName).
+        # GetObject is not needed — file transfers use presigned URLs generated
+        # by the eval host.  DeleteObject is not needed — the eval host cleans
+        # up.  ListBucket is required because the SSM agent calls HeadBucket
+        # for region discovery (HeadBucket is gated on s3:ListBucket).
+        # GetEncryptionConfiguration is needed because the SSM agent calls
+        # GetBucketEncryption to determine SSE headers before uploading.
         self.instance_role.add_to_policy(
             iam.PolicyStatement(
                 actions=[
-                    "s3:GetObject",
                     "s3:PutObject",
-                    "s3:DeleteObject",
+                ],
+                resources=[
+                    f"{self.bucket.bucket_arn}/*",
+                ],
+            )
+        )
+        self.instance_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
                     "s3:ListBucket",
+                    "s3:GetEncryptionConfiguration",
                 ],
                 resources=[
                     self.bucket.bucket_arn,
-                    f"{self.bucket.bucket_arn}/*",
                 ],
             )
         )

--- a/src/ec2sandbox/__init__.py
+++ b/src/ec2sandbox/__init__.py
@@ -1,1 +1,17 @@
 """Package for an EC2 sandbox environment provider for Inspect AI."""
+
+from ec2sandbox._instance_provider import (
+    Ec2InstanceProvider,
+    ProvisionedInstance,
+    SandboxInstanceInfo,
+    get_ec2_instance_provider,
+    set_ec2_instance_provider,
+)
+
+__all__ = [
+    "Ec2InstanceProvider",
+    "ProvisionedInstance",
+    "SandboxInstanceInfo",
+    "get_ec2_instance_provider",
+    "set_ec2_instance_provider",
+]

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -27,6 +27,11 @@ from rich.table import Table
 from tenacity import retry, stop_after_attempt, wait_fixed
 from typing_extensions import Literal, override
 
+from ec2sandbox._instance_provider import (
+    Ec2InstanceProvider,
+    SandboxInstanceInfo,
+    get_ec2_instance_provider,
+)
 from ec2sandbox.schema import Ec2SandboxEnvironmentConfig
 
 from ._unpack_tags import convert_tags_for_aws_interface
@@ -57,22 +62,26 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
 
     logger = getLogger(__name__)
 
-    config: Ec2SandboxEnvironmentConfig
-    s3_client: boto3.client
-    ssm_client: boto3.client
-
     TRACE_NAME = "ec2_sandbox_environment"
 
-    def __init__(self, config: Ec2SandboxEnvironmentConfig, instance_id: str):
-        self.config = config
+    def __init__(
+        self,
+        instance_id: str,
+        region: str,
+        s3_bucket: str,
+        s3_key_prefix: str = "",
+    ):
         self.instance_id = instance_id
-        self.ssm_client = boto3.client("ssm", region_name=config.region)
+        self.region = region
+        self.s3_bucket = s3_bucket
+        self.s3_key_prefix = s3_key_prefix
+        self.ssm_client = boto3.client("ssm", region_name=region)
         self.s3_client = boto3.client(
             "s3",
-            region_name=config.region,
-            endpoint_url=f"https://s3.{config.region}.amazonaws.com",
+            region_name=region,
+            endpoint_url=f"https://s3.{region}.amazonaws.com",
         )
-        self.ec2_client = boto3.client("ec2", region_name=config.region)
+        self.ec2_client = boto3.client("ec2", region_name=region)
 
     @classmethod
     @override
@@ -89,6 +98,55 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         metadata: dict[str, str],
     ) -> dict[str, SandboxEnvironment]:
+        provider = get_ec2_instance_provider()
+
+        # Base tags shared by both the custom-provider and default paths.
+        # Each path prepends config.extra_tags in its own way.
+        tags = [
+            ("Name", f"inspect_ec2_sandbox_{task_name}"),
+            ("inspect_task", task_name),
+            (MARKER_TAG_KEY, "true"),
+        ]
+
+        if provider is not None:
+            # Custom provider path — provider handles all provisioning.
+            instance_type = (
+                config.instance_type
+                if isinstance(config, Ec2SandboxEnvironmentConfig)
+                else "t3a.large"
+            )
+            ami_id = (
+                config.ami_id
+                if isinstance(config, Ec2SandboxEnvironmentConfig)
+                else ""
+            )
+            if isinstance(config, Ec2SandboxEnvironmentConfig) and config.extra_tags:
+                tags = list(config.extra_tags) + tags
+
+            cls.logger.debug(
+                "sample_init: custom provider, type=%s ami=%s",
+                instance_type,
+                ami_id,
+            )
+            result = await provider.create_instance(
+                instance_type=instance_type,
+                ami_id=ami_id,
+                tags=tags,
+            )
+            cls.logger.debug(
+                "sample_init: provider returned id=%s region=%s",
+                result.instance_id,
+                result.region,
+            )
+            environment = Ec2SandboxEnvironment(
+                instance_id=result.instance_id,
+                region=result.region,
+                s3_bucket=result.s3_bucket,
+                s3_key_prefix=result.s3_key_prefix,
+            )
+            return {"default": environment}
+
+        # Default path — direct EC2/SSM calls using Ec2SandboxEnvironmentConfig.
         if config is None:
             config = Ec2SandboxEnvironmentConfig.from_settings()
         if not isinstance(config, Ec2SandboxEnvironmentConfig):
@@ -96,11 +154,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
 
         ec2_client = boto3.client("ec2", region_name=config.region)
 
-        specified_tags = config.extra_tags
-        tags = list(specified_tags)
-        tags.append(("Name", f"inspect_ec2_sandbox_{task_name}"))
-        tags.append(("inspect_task", task_name))
-        tags.append((MARKER_TAG_KEY, "true"))
+        tags = list(config.extra_tags) + tags
 
         instance_params = {
             "ImageId": config.ami_id,
@@ -119,9 +173,14 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         waiter = ec2_client.get_waiter("instance_running")
         waiter.wait(InstanceIds=[instance["InstanceId"]])
 
-        environment = Ec2SandboxEnvironment(config, instance["InstanceId"])
+        _wait_for_ssm(instance["InstanceId"], config.region)
 
-        _wait_for_ssm(environment.instance_id, config.region)
+        environment = Ec2SandboxEnvironment(
+            instance_id=instance["InstanceId"],
+            region=config.region,
+            s3_bucket=config.s3_bucket,
+            s3_key_prefix=config.s3_key_prefix,
+        )
 
         return {"default": environment}
 
@@ -135,11 +194,15 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         interrupted: bool,
     ) -> None:
         if not interrupted:
+            provider = get_ec2_instance_provider()
             for env in environments.values():
                 if isinstance(env, Ec2SandboxEnvironment):
-                    env.ec2_client.terminate_instances(
-                        InstanceIds=[env.instance_id]
-                    )
+                    if provider is not None:
+                        await provider.terminate_instance(env.instance_id, env.region)
+                    else:
+                        env.ec2_client.terminate_instances(
+                            InstanceIds=[env.instance_id]
+                        )
         return None
 
     @classmethod
@@ -195,65 +258,110 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     @override
     async def cli_cleanup(cls, id: str | None) -> None:
         if id is None:
-            ec2 = boto3.client("ec2")
-            response = ec2.describe_instances(
-                Filters=[
-                    {
-                        "Name": f"tag:{MARKER_TAG_KEY}",
-                        "Values": ["true"],
-                    },
-                    {
-                        "Name": "instance-state-name",
-                        "Values": ["pending", "running", "stopping", "stopped"],
-                    },
-                ]
-            )
-            instances = []
-            for reservation in response["Reservations"]:
-                for instance in reservation["Instances"]:
-                    instances.append(instance)
+            provider = get_ec2_instance_provider()
 
-            if instances:
-                vms_table = Table(
-                    box=box.SQUARE,
-                    show_lines=False,
-                    title_style="bold",
-                    title_justify="left",
-                )
-                vms_table.add_column("Instance ID")
-                vms_table.add_column("Instance Name")
-                for instance in instances:
-                    name_tag = ""
-                    if "Tags" in instance:
-                        for tag in instance["Tags"]:
-                            if tag["Key"] == "Name":
-                                name_tag = tag["Value"]
-                                break
-
-                    vms_table.add_row(instance["InstanceId"], name_tag)
-                print(vms_table)
-
-                # Borrowed from the proxmox provider - only prompt if in an interactive shell  # noqa: E501
-                is_interactive_shell = sys.stdin.isatty()
-                is_ci = "CI" in os.environ
-                is_pytest = "PYTEST_CURRENT_TEST" in os.environ
-
-                if is_interactive_shell and not is_ci and not is_pytest:
-                    if not Confirm.ask(
-                        "Are you sure you want to delete ALL the above resources?",
-                    ):
-                        print("Cancelled.")
-                        return
-
-                instance_ids = []
-                for instance in instances:
-                    instance_ids.append(instance["InstanceId"])
-                ec2.terminate_instances(InstanceIds=list(instance_ids))
-
+            if provider is not None:
+                region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", ""))
+                sandbox_infos = await provider.find_sandbox_instances(region)
+                await cls._cli_cleanup_provider(provider, sandbox_infos, region)
             else:
-                print("\nNo EC2 sandbox instances found to clean up.\n")
+                await cls._cli_cleanup_default()
         else:
             print("\n[red]Cleanup by ID not implemented[/red]\n")
+
+    @classmethod
+    async def _cli_cleanup_provider(
+        cls,
+        provider: "Ec2InstanceProvider",
+        instances: list[SandboxInstanceInfo],
+        fallback_region: str,
+    ) -> None:
+        if not instances:
+            print("\nNo EC2 sandbox instances found to clean up.\n")
+            return
+
+        vms_table = Table(
+            box=box.SQUARE, show_lines=False,
+            title_style="bold", title_justify="left",
+        )
+        vms_table.add_column("Instance ID")
+        vms_table.add_column("Instance Name")
+        for inst in instances:
+            vms_table.add_row(inst.instance_id, inst.name)
+        print(vms_table)
+
+        if not cls._confirm_cleanup():
+            return
+
+        for inst in instances:
+            region = inst.region or fallback_region
+            await provider.terminate_instance(inst.instance_id, region)
+
+    @classmethod
+    async def _cli_cleanup_default(cls) -> None:
+        ec2 = boto3.client("ec2")
+        response = ec2.describe_instances(
+            Filters=[
+                {
+                    "Name": f"tag:{MARKER_TAG_KEY}",
+                    "Values": ["true"],
+                },
+                {
+                    "Name": "instance-state-name",
+                    "Values": [
+                        "pending",
+                        "running",
+                        "stopping",
+                        "stopped",
+                    ],
+                },
+            ]
+        )
+        instances = []
+        for reservation in response["Reservations"]:
+            for instance in reservation["Instances"]:
+                instances.append(instance)
+
+        if not instances:
+            print("\nNo EC2 sandbox instances found to clean up.\n")
+            return
+
+        vms_table = Table(
+            box=box.SQUARE, show_lines=False,
+            title_style="bold", title_justify="left",
+        )
+        vms_table.add_column("Instance ID")
+        vms_table.add_column("Instance Name")
+        for instance in instances:
+            name_tag = ""
+            if "Tags" in instance:
+                for tag in instance["Tags"]:
+                    if tag["Key"] == "Name":
+                        name_tag = tag["Value"]
+                        break
+            vms_table.add_row(instance["InstanceId"], name_tag)
+        print(vms_table)
+
+        if not cls._confirm_cleanup():
+            return
+
+        instance_ids = [inst["InstanceId"] for inst in instances]
+        ec2.terminate_instances(InstanceIds=instance_ids)
+
+    @staticmethod
+    def _confirm_cleanup() -> bool:
+        # Borrowed from the proxmox provider - only prompt if in an interactive shell
+        is_interactive_shell = sys.stdin.isatty()
+        is_ci = "CI" in os.environ
+        is_pytest = "PYTEST_CURRENT_TEST" in os.environ
+
+        if is_interactive_shell and not is_ci and not is_pytest:
+            if not Confirm.ask(
+                "Are you sure you want to delete ALL the above resources?",
+            ):
+                print("Cancelled.")
+                return False
+        return True
 
     @classmethod
     def config_deserialize(cls, config: dict[str, Any]) -> BaseModel:
@@ -262,7 +370,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     def _delete_s3_object(self, key: str) -> None:
         """Delete an object from S3 after it's no longer needed."""
         try:
-            self.s3_client.delete_object(Bucket=self.config.s3_bucket, Key=key)
+            self.s3_client.delete_object(Bucket=self.s3_bucket, Key=key)
             self.logger.debug(f"Deleted S3 object: {key}")
         except Exception as e:
             self.logger.warning(f"Failed to delete S3 object {key}: {e}")
@@ -271,13 +379,13 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         """Delete all objects with a given prefix from S3."""
         try:
             response = self.s3_client.list_objects_v2(
-                Bucket=self.config.s3_bucket, Prefix=prefix
+                Bucket=self.s3_bucket, Prefix=prefix
             )
             if "Contents" in response:
                 objects = [{"Key": obj["Key"]} for obj in response["Contents"]]
                 if objects:
                     self.s3_client.delete_objects(
-                        Bucket=self.config.s3_bucket, Delete={"Objects": objects}
+                        Bucket=self.s3_bucket, Delete={"Objects": objects}
                     )
                     self.logger.debug(f"Deleted S3 objects with prefix: {prefix}")
         except Exception as e:
@@ -288,16 +396,21 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     def _run_command(
         self, s3_key_prefix: str, params: dict[str, Any], timeout: int | None
     ) -> ExecResult:
+        self.logger.debug(
+            "send_command: instance=%s bucket=%s prefix=%s params=%s",
+            self.instance_id, self.s3_bucket, s3_key_prefix, params,
+        )
         # Send command using Session Manager with S3 output
         response = self.ssm_client.send_command(
             InstanceIds=[self.instance_id],
             DocumentName="AWS-RunShellScript",
             Parameters=params,
-            OutputS3BucketName=self.config.s3_bucket,
+            OutputS3BucketName=self.s3_bucket,
             OutputS3KeyPrefix=s3_key_prefix,
         )
 
         command_id = response["Command"]["CommandId"]
+        self.logger.debug("send_command returned command_id=%s", command_id)
 
         stdout_key = (
             f"{s3_key_prefix}{command_id}/{self.instance_id}"
@@ -309,6 +422,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             "/awsrunShellScript/0.awsrunShellScript/"
             "stderr"
         )
+        self.logger.debug("stdout_key=%s stderr_key=%s", stdout_key, stderr_key)
 
         try:
             # Wait for command completion
@@ -319,6 +433,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
                 InstanceId=self.instance_id,
                 WaiterConfig={"Delay": 1, "MaxAttempts": timeout or 3600},
             )
+            self.logger.debug("waiter completed for command_id=%s", command_id)
 
             # Get command output from S3
 
@@ -327,6 +442,10 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             )
             stderr = self._read_s3_file_or_blank(
                 stderr_key, limit_bytes=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE
+            )
+            self.logger.debug(
+                "s3 read: stdout=%r (%d bytes) stderr=%r (%d bytes)",
+                stdout[:200], len(stdout), stderr[:200], len(stderr),
             )
 
             # Still get return code from SSM API as it's not stored in S3
@@ -364,6 +483,12 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         self._delete_s3_object(stderr_key)
         self._delete_s3_prefix(f"{s3_key_prefix}{command_id}/")
 
+        self.logger.debug(
+            "ExecResult: rc=%s stdout=%d bytes stderr=%d bytes",
+            return_code,
+            len(stdout),
+            len(stderr),
+        )
         return ExecResult(
             success=return_code == 0,
             returncode=return_code,
@@ -373,10 +498,21 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
 
     def _get_s3_file_size(self, key: str) -> int:
         try:
-            response = self.s3_client.head_object(Bucket=self.config.s3_bucket, Key=key)
-            return response.get("ContentLength", 0)
+            self.logger.debug("head_object: bucket=%s key=%s", self.s3_bucket, key)
+            response = self.s3_client.head_object(Bucket=self.s3_bucket, Key=key)
+            size = response.get("ContentLength", 0)
+            self.logger.debug("head_object: key=%s size=%d", key, size)
+            return size
         except ClientError as e:
-            if e.response and e.response.get("Error", {}).get("Code", None) == "404":
+            error_code = (
+                e.response.get("Error", {}).get("Code")
+                if e.response
+                else None
+            )
+            self.logger.debug(
+                "head_object error: key=%s code=%s", key, error_code
+            )
+            if error_code == "404":
                 raise KeyError(key)
             else:
                 raise
@@ -389,7 +525,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             if file_size >= limit_bytes:
                 # File is larger than limit, use Range to get only what we need
                 stdout_response = self.s3_client.get_object(
-                    Bucket=self.config.s3_bucket,
+                    Bucket=self.s3_bucket,
                     Key=key,
                     Range=f"bytes=0-{limit_bytes - 1}",
                 )
@@ -400,7 +536,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             else:
                 # File is smaller than limit, get entire file without Range
                 stdout_response = self.s3_client.get_object(
-                    Bucket=self.config.s3_bucket, Key=key
+                    Bucket=self.s3_bucket, Key=key
                 )
                 response_body = stdout_response["Body"].read()
                 return response_body.decode("utf-8")
@@ -411,16 +547,21 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             # Unfortunately it makes it harder in the case of misconfiguration
             # of S3 permissions, since in that case we would also not have anything
             # in S3.
-            self.logger.debug(f"Could not retrieve {key} from S3: {e}")
+            self.logger.debug(
+                "S3 key not found (returning empty): key=%s",
+                key,
+            )
             return ""
 
     @override
-    async def read_file(self, file: str, text: bool = True) -> Union[str, bytes]:  # type: ignore
+    async def read_file(  # type: ignore
+        self, file: str, text: bool = True
+    ) -> Union[str, bytes]:
         file_key = self._s3_key_prefix("read_file") + file
 
         url = self.s3_client.generate_presigned_url(
             "put_object",
-            Params={"Bucket": self.config.s3_bucket, "Key": file_key},
+            Params={"Bucket": self.s3_bucket, "Key": file_key},
             ExpiresIn=60,
         )
 
@@ -471,7 +612,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             if file_size >= SandboxEnvironmentLimits.MAX_READ_FILE_SIZE:
                 # File is larger than limit, use Range to get only what we need
                 response = self.s3_client.get_object(
-                    Bucket=self.config.s3_bucket,
+                    Bucket=self.s3_bucket,
                     Key=file_key,
                     Range=f"bytes=0-{SandboxEnvironmentLimits.MAX_READ_FILE_SIZE - 1}",
                 )
@@ -484,7 +625,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             else:
                 # File is smaller than limit, get entire file without Range
                 response = self.s3_client.get_object(
-                    Bucket=self.config.s3_bucket,
+                    Bucket=self.s3_bucket,
                     Key=file_key,
                 )
                 response_body = response["Body"].read()
@@ -512,14 +653,14 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         file_key = self._s3_key_prefix("write_file") + file
 
         self.s3_client.put_object(
-            Bucket=self.config.s3_bucket,
+            Bucket=self.s3_bucket,
             Key=file_key,
             Body=contents,
         )
 
         url = self.s3_client.generate_presigned_url(
             "get_object",
-            Params={"Bucket": self.config.s3_bucket, "Key": file_key},
+            Params={"Bucket": self.s3_bucket, "Key": file_key},
             ExpiresIn=60,
         )
 
@@ -581,4 +722,4 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     ) -> str:
         rand = "".join(random.choices(string.ascii_letters + string.digits, k=8))
         timestamp = datetime.now().isoformat()
-        return f"{self.config.s3_key_prefix}{operation}/{timestamp}-{rand}/"
+        return f"{self.s3_key_prefix}{operation}/{timestamp}-{rand}/"

--- a/src/ec2sandbox/_instance_provider.py
+++ b/src/ec2sandbox/_instance_provider.py
@@ -1,0 +1,111 @@
+"""Protocol and registry for EC2 instance lifecycle management.
+
+The EC2 sandbox provider delegates instance creation, termination, and
+discovery to an ``Ec2InstanceProvider``.  By default no custom provider
+is registered and the sandbox falls back to direct boto3 EC2/SSM calls.
+
+External packages (e.g. an organisational wrapper that routes through a
+Lambda or other control plane) can register an alternative provider at
+import time via :func:`set_ec2_instance_provider`.  The Inspect entry-
+point mechanism ensures that such packages are imported before the
+sandbox is used.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProvisionedInstance:
+    """Result of provisioning an EC2 sandbox instance.
+
+    Contains everything the :class:`Ec2SandboxEnvironment` needs for
+    runtime operations (exec / read_file / write_file via SSM + S3).
+    """
+
+    instance_id: str
+    region: str
+    s3_bucket: str
+    s3_key_prefix: str = ""
+
+
+@dataclass
+class SandboxInstanceInfo:
+    """Metadata for a discovered sandbox instance (used by cli_cleanup)."""
+
+    instance_id: str
+    name: str
+    region: str
+
+
+@runtime_checkable
+class Ec2InstanceProvider(Protocol):
+    """Protocol for EC2 instance lifecycle management.
+
+    The default code path calls the EC2 and SSM APIs directly using
+    credentials available to the caller.  Implement this protocol and
+    register it with :func:`set_ec2_instance_provider` to route instance
+    lifecycle through a different control plane (e.g. an organisational
+    Lambda / API).
+    """
+
+    async def create_instance(
+        self,
+        instance_type: str,
+        ami_id: str,
+        tags: list[tuple[str, str]],
+    ) -> ProvisionedInstance:
+        """Create an EC2 instance and wait until it is SSM-ready.
+
+        Args:
+            instance_type: EC2 instance type (e.g. ``"t3a.large"``).
+            ami_id: AMI to launch.  May be empty if the provider
+                resolves its own AMI.
+            tags: Key/value pairs to apply to the instance.
+
+        Returns:
+            A :class:`ProvisionedInstance` with the runtime config
+            needed by the sandbox environment.
+        """
+        ...
+
+    async def terminate_instance(self, instance_id: str, region: str) -> None:
+        """Terminate an EC2 instance."""
+        ...
+
+    async def find_sandbox_instances(self, region: str) -> list[SandboxInstanceInfo]:
+        """Find running sandbox instances for interactive cleanup."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Module-level provider registry
+# ---------------------------------------------------------------------------
+
+_provider: Ec2InstanceProvider | None = None
+
+
+def set_ec2_instance_provider(provider: Ec2InstanceProvider) -> None:
+    """Register a custom :class:`Ec2InstanceProvider`.
+
+    Call this at import time (e.g. from an ``inspect_ai`` entry-point
+    module) to override the default direct-boto3 instance lifecycle.
+    """
+    global _provider
+    if _provider is not None:
+        _logger.warning(
+            "Overriding existing Ec2InstanceProvider %r with %r",
+            type(_provider).__name__,
+            type(provider).__name__,
+        )
+    _provider = provider
+
+
+def get_ec2_instance_provider() -> Ec2InstanceProvider | None:
+    """Return the registered provider, or ``None`` for the default path."""
+    return _provider

--- a/uv.lock
+++ b/uv.lock
@@ -176,18 +176,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aisitools"
-version = "0.4.0"
-source = { git = "ssh://git@github.com/AI-Safety-Institute/aisi-inspect-tools.git#4a7fab953f39466d0ab3e409d872e52fa6c31ed1" }
-dependencies = [
-    { name = "aiobotocore" },
-    { name = "boto3" },
-    { name = "click" },
-    { name = "inspect-ai" },
-    { name = "json-stream" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -351,7 +339,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -683,7 +671,6 @@ name = "inspect-ec2-sandbox"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "aisitools" },
     { name = "boto3" },
     { name = "httpx" },
     { name = "inspect-ai" },
@@ -706,7 +693,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aisitools", git = "ssh://git@github.com/AI-Safety-Institute/aisi-inspect-tools.git" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "inspect-ai", specifier = ">=0.3.79" },
@@ -734,60 +720,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "json-stream"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "json-stream-rs-tokenizer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/3a/18dc5aaf006e19632bb0cb3d14854ff7c8b84d18a65fda10f09a41495f44/json_stream-2.4.1.tar.gz", hash = "sha256:9491041faae7ea05fdd3d40768b8f9ee7ea4e40b168f27240b028a8bb0a1a3c2", size = 35170, upload-time = "2025-11-08T10:26:57.175Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/42/754adf29fd19e81024dc507bcf42d4184c89210c3db0f1c866f4b658214c/json_stream-2.4.1-py3-none-any.whl", hash = "sha256:d31dc2dbc8586c21a6e71e4bf4868133f86c53fc7fd62eb482005db579a6e3e6", size = 35009, upload-time = "2025-11-08T10:26:55.83Z" },
-]
-
-[[package]]
-name = "json-stream-rs-tokenizer"
-version = "0.4.32"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/d0/1d4f41f98b77f9f475819b112372eccf1b6821f46da5fca732845c845850/json_stream_rs_tokenizer-0.4.32.tar.gz", hash = "sha256:dbc26f496e54004e5b8f708a5c9d6ae0fa4d8e97df0823a15a13538464e5a1a9", size = 34912, upload-time = "2025-11-10T21:13:46.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8e/b7a1fd9e9272afc72fb653eecd347a428b28085d4074fa322c0e3d49f02c/json_stream_rs_tokenizer-0.4.32-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:b1860f887c45493c22b4eda37387f7c29f802c7bbd866d0d8269ca3f8602aec5", size = 302086, upload-time = "2025-11-10T21:12:37.871Z" },
-    { url = "https://files.pythonhosted.org/packages/17/eb/9ae339cfa75b027b0b2ffb7fecf1551cc3b0fa00801270312fd413bf9649/json_stream_rs_tokenizer-0.4.32-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:62a526bc7c24210c6434ea1d6c6828fc17afba6679235a180eb33fb458f2974c", size = 293411, upload-time = "2025-11-10T21:12:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/a8/67548c1324488f15cfc93b57cf8cbc52b3b0a5df7d29952bc8f72e8832fb/json_stream_rs_tokenizer-0.4.32-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1ba67053c99d1427a7c53966136c0b2054d871d3a6623832461d1cc63bbf5230", size = 326937, upload-time = "2025-11-10T21:12:41.701Z" },
-    { url = "https://files.pythonhosted.org/packages/43/db/89cac4057c26c681f48f0437760b0975021e20da26efc0f76ff58509d97d/json_stream_rs_tokenizer-0.4.32-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7521aac96a90847b015d73ba55925f93a3ef16e990958df4e206a09235280f1f", size = 336457, upload-time = "2025-11-10T21:12:43.035Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/53/9dc11b50fda179e5d4f7868b12dca49f6984fff6baaa25c691d873fa87f7/json_stream_rs_tokenizer-0.4.32-cp310-cp310-win32.whl", hash = "sha256:2e16d4902df0cbe31d8015ce5d687f2febc3bcfb9fd591d048187e9a8f653f0f", size = 176523, upload-time = "2025-11-10T21:12:44.741Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/dc/6862964e3a9a9ca44cbdc839bb9bcc43ba465f0575692191ed66ceabed32/json_stream_rs_tokenizer-0.4.32-cp310-cp310-win_amd64.whl", hash = "sha256:e3399f777d4e0396d6b7d204991a47916d2b74b757313ef3434302d6af1e762d", size = 182218, upload-time = "2025-11-10T21:12:46.282Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7a/7b8f2fb7c6078b0dea0567b80ddc98098b7e3e1fa9c4fe2e4fc093117c63/json_stream_rs_tokenizer-0.4.32-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b89ac788184c69239f48040ccbc197e3d340453d353eb5e304162a130d8b763d", size = 301700, upload-time = "2025-11-10T21:12:47.919Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/63/c116e78d39c498fa16a5413f219acb4ffbfc3a14f02cf69a520d89de7cdd/json_stream_rs_tokenizer-0.4.32-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5bfef957bc89794c8316929549dc40cdef7da108a36f4be86388ea387bd98e2c", size = 293240, upload-time = "2025-11-10T21:12:49.979Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3a/3c370026c57736fc06384552d9302c2a9918d4ea60a85ad2f4757063ff9c/json_stream_rs_tokenizer-0.4.32-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6630bfcaa4d0c8fde03e835051efc9bafffc0fa2ded23a4904b90229780513ba", size = 326858, upload-time = "2025-11-10T21:12:51.322Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/36/e815f21f08279a0ad9ff4d2756bd09cc9e8b9e095b8b81832195cedbdc56/json_stream_rs_tokenizer-0.4.32-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:51e50404201755fea9c35a3ad4127457206ce400fec8dde2ad2dec13062eb551", size = 336717, upload-time = "2025-11-10T21:12:53.093Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/7e/2726a3297d10c4ac584aa33269fff95ce025a36968683aeb13d58af01ada/json_stream_rs_tokenizer-0.4.32-cp311-cp311-win32.whl", hash = "sha256:7c12e9cb3e24a65f45b93856c3398a8bd30c08b8436f00dac38032c843309dcf", size = 176423, upload-time = "2025-11-10T21:12:54.426Z" },
-    { url = "https://files.pythonhosted.org/packages/79/76/5a15689dae902293a86102c465ff5066a8d83906e3d354ce5c7438172c4f/json_stream_rs_tokenizer-0.4.32-cp311-cp311-win_amd64.whl", hash = "sha256:d354eae13d934d688b9589aed605cd25110035afb6b703dd8ee793e162d51c52", size = 182588, upload-time = "2025-11-10T21:12:55.734Z" },
-    { url = "https://files.pythonhosted.org/packages/23/36/e9738509a0245fcf6ae4372f2b0ba76c8be6e1b23f7de9e0e94d559912c8/json_stream_rs_tokenizer-0.4.32-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:066d8a0d1e3dfdb65cbd9edd8ec972f6d150cc16e140ed672001885f0f2b3a7d", size = 300926, upload-time = "2025-11-10T21:12:57.343Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/93/384caeaff520b675650d9c34b3356913d764b8ebb007a1820daf424a162b/json_stream_rs_tokenizer-0.4.32-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6a299e22cd90dcd5ce0b10b30790f7910feba24adfc530f3c6230ed18db22a30", size = 291490, upload-time = "2025-11-10T21:12:58.575Z" },
-    { url = "https://files.pythonhosted.org/packages/47/aa/d180f2ff3b92b6b9ee3887ba1940f1d37109c4c62d02f9847a360a7ceec3/json_stream_rs_tokenizer-0.4.32-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f973d4d7441ab877e5be97dd87c367ca0c85ef780ace977b786b1f4d0ef9a6c8", size = 325776, upload-time = "2025-11-10T21:13:00.217Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2c/23dd36535a92b20899ac1dfd5636de94e795498e65ca05c8cdbdf59e3ea1/json_stream_rs_tokenizer-0.4.32-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3fb635a25a8ac03e6ec48d2cff394ae08cce8a5816572bafd9b70302df78393a", size = 334929, upload-time = "2025-11-10T21:13:01.991Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/85/064daac95083caf11d025010505db28c41307015645e44fa3a5d82644583/json_stream_rs_tokenizer-0.4.32-cp312-cp312-win32.whl", hash = "sha256:d3d837435e4e211cbc9462a6316a2e6f58502f39e80835d54dc69c76c9e9d478", size = 173873, upload-time = "2025-11-10T21:13:03.26Z" },
-    { url = "https://files.pythonhosted.org/packages/45/47/b7cf0274c88a621d55f841756f207683a805a48c7723fe7fb59d02f9daba/json_stream_rs_tokenizer-0.4.32-cp312-cp312-win_amd64.whl", hash = "sha256:1448da96c47510aa13d7e3d69d398a5c68d6fd64d33ec69ddd9322fa4f4e30d8", size = 181397, upload-time = "2025-11-10T21:13:05.051Z" },
-    { url = "https://files.pythonhosted.org/packages/74/fd/e04a8e1251cb91b619910fc6306df7b4e96962e2d7271730b957030ac5da/json_stream_rs_tokenizer-0.4.32-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d871712a1690ec303da1fbe3e5ebc082bdef03ffc0c8ada5cf8e15a6a3c4c9a0", size = 300671, upload-time = "2025-11-10T21:13:06.352Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/0f/5a57f78e3da0540f6dfb278c30a8b22d5a0c207afb703818e6d503bdf865/json_stream_rs_tokenizer-0.4.32-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b563ebbed598553754f3713756250fed3f9407e867540f864e1af19ac1037062", size = 291499, upload-time = "2025-11-10T21:13:07.836Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/68/ae289642185efc1a50ba4e2c7aa0ea50e509a6394300e1577e189578a20e/json_stream_rs_tokenizer-0.4.32-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:74f9e8febdee5a6f2bd87bb0418f5beac19a550622ebb3a81fc5657c0a328dd4", size = 324802, upload-time = "2025-11-10T21:13:09.338Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f9/983f5abcecc0ba18ce4e4f6b959864a422c00177fc411867aa976750c496/json_stream_rs_tokenizer-0.4.32-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:14a132682c6298af933913d6a101b841da3d362f4e0c353ab2bf9451a5d5fd44", size = 334093, upload-time = "2025-11-10T21:13:10.678Z" },
-    { url = "https://files.pythonhosted.org/packages/80/92/a1abd85154612d44cc3e34dfc4ea74478dbb0f06996fb8c8c4ae7683b0cc/json_stream_rs_tokenizer-0.4.32-cp313-cp313-win32.whl", hash = "sha256:af9a15f87fe81dd24e1c66dcf01d38a45bc37307e2f7efd19a3c2ca1ea1c62cb", size = 173925, upload-time = "2025-11-10T21:13:12.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/60/7c7a5745c34aeb3437d7b2c2bdd28191aaf0f49086b55abc6de474efb965/json_stream_rs_tokenizer-0.4.32-cp313-cp313-win_amd64.whl", hash = "sha256:66536a44d4b54ed5f55d67be0a27244d3b3fe354d926c5e979612d4d7210ce3a", size = 181321, upload-time = "2025-11-10T21:13:14.025Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/52/c80656fbc28becbce2e57dbe30750de863918a18138d80dfa30d92bd9273/json_stream_rs_tokenizer-0.4.32-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f98cd65a3933c3f7a9e30f637648c29e83c7bec2d6558f7e200eea277045dac", size = 299940, upload-time = "2025-11-10T21:13:15.647Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/36/6ace928c5ceab84c25c8947008873055ff8ce6ef7bb8cb8c30cf829647e2/json_stream_rs_tokenizer-0.4.32-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:098d5e4b8237915bff404f50460d69b61c495f15347327318e493c5799af4d4f", size = 291054, upload-time = "2025-11-10T21:13:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/56/e7629da25066dc9a66e41e42280681e81cf3e52eaef13f271871bf7aa770/json_stream_rs_tokenizer-0.4.32-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9ae4d75e27211e1b8f0a4c9de5e722f9c660b42c52f3abe564e739b17536d25e", size = 324242, upload-time = "2025-11-10T21:13:18.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f9/c0147e00947200c30e0ed2c6f653d3a6f4c841ae40e408ef9507ab7ffd03/json_stream_rs_tokenizer-0.4.32-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:67841ce9455b5f4fc5cc1cbe9fb26dffd625c0b8f4d4335934bd025aa241422a", size = 334110, upload-time = "2025-11-10T21:13:19.921Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/22/ca50f9fbe1bd90101e5f02de115ffbf46675309e83e0ca6a4462d1d2fbc6/json_stream_rs_tokenizer-0.4.32-cp314-cp314-win32.whl", hash = "sha256:7a6f3e6bae7b97ef5aadf98b2808ea96a84015a8cdea4a5ebaaa07c9cb502861", size = 178072, upload-time = "2025-11-10T21:13:21.198Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/f5/8afccd84c19014861eb0595f4a48b38dd3a3209184b8ff0d09c29f1051c9/json_stream_rs_tokenizer-0.4.32-cp314-cp314-win_amd64.whl", hash = "sha256:eb1939eda685346e3a50864b26b4ec056ebe1fb9076581db1f4159f5f129abf5", size = 185606, upload-time = "2025-11-10T21:13:22.435Z" },
-    { url = "https://files.pythonhosted.org/packages/76/8d/ddbf17285689ca9ad48fce663369e9fdc95397ad4b5da92ea6e65fcab3fe/json_stream_rs_tokenizer-0.4.32-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:19eec24d6f3d6b499eab82d4573c7c2bbefe19714b80b837dc3005307006e4c6", size = 296352, upload-time = "2025-11-10T21:13:40.92Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/59/9e43f602a24b57d406a3bf37c27358de3ea10a19bec0f43f5479d1501cf8/json_stream_rs_tokenizer-0.4.32-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bfd79d1093904da58dec04a161ee200aff32036e2ac0c25806e8896cf4a0d04e", size = 320557, upload-time = "2025-11-10T21:13:42.573Z" },
-    { url = "https://files.pythonhosted.org/packages/82/97/34387994b7e06866c1264517453a777de05a868eb97cf7e3266a7bdfad32/json_stream_rs_tokenizer-0.4.32-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:442850e5d27a21189203d28e3468fa3b7cf3fa3efb1b98c8c568d178189a21c9", size = 331790, upload-time = "2025-11-10T21:13:43.945Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/4d/efcc7f4761de8242b808f0eec8bc1264d8cf106f8888d7ae34e387dd4713/json_stream_rs_tokenizer-0.4.32-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cacab850d3687d997204ce3b17cb4f6bdf2f24458eff5c06f4660d80d6106547", size = 176995, upload-time = "2025-11-10T21:13:45.631Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Allow external packages to override EC2 instance creation, termination, and discovery by registering an Ec2InstanceProvider via set_ec2_instance_provider(). When no provider is registered, the existing direct-boto3 code path is used unchanged.

This enables organisational wrappers (e.g. routing through a Lambda or internal API) without any org-specific code in this package.

Also refactors Ec2SandboxEnvironment.__init__ to take runtime fields (instance_id, region, s3_bucket, s3_key_prefix) directly instead of the full Ec2SandboxEnvironmentConfig, since the config is only needed for the default provisioning path.