### PR TITLE
Forward exec input/user, factor out DefaultEc2InstanceProvider

### DIFF
--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -1,3 +1,4 @@
+import base64
 import errno
 import os
 import random
@@ -24,37 +25,20 @@ from pydantic import BaseModel
 from rich import box, print
 from rich.prompt import Confirm
 from rich.table import Table
-from tenacity import retry, stop_after_attempt, wait_fixed
 from typing_extensions import Literal, override
 
 from ec2sandbox._instance_provider import (
+    MARKER_TAG_KEY,
+    DefaultEc2InstanceProvider,
     Ec2InstanceProvider,
-    SandboxInstanceInfo,
     get_ec2_instance_provider,
     get_provider_session,
 )
 from ec2sandbox.schema import Ec2SandboxEnvironmentConfig
 
-from ._unpack_tags import convert_tags_for_aws_interface
-
-
-@retry(stop=stop_after_attempt(20), wait=wait_fixed(30))
-def _wait_for_ssm(instance_id: str, ssm_client: Any) -> bool:
-    """Wait for SSM agent to come online on the given instance."""
-    resp = ssm_client.describe_instance_information(
-        InstanceInformationFilterList=[
-            {"key": "InstanceIds", "valueSet": [instance_id]}
-        ]
-    )
-    if (
-        not resp["InstanceInformationList"]
-        or resp["InstanceInformationList"][0]["PingStatus"] != "Online"
-    ):
-        raise Exception("Not ready")
-    return True
-
-
-MARKER_TAG_KEY = "inspect_sandbox"
+# Re-exported for backward compatibility — callers used to import
+# ``MARKER_TAG_KEY`` from this module.
+__all__ = ["Ec2SandboxEnvironment", "Ec2SandboxEnvironmentConfig", "MARKER_TAG_KEY"]
 
 
 @sandboxenv(name="ec2")
@@ -118,6 +102,37 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             cls._get_session()
 
     @classmethod
+    def _resolve_provider(
+        cls, config: SandboxEnvironmentConfigType | None
+    ) -> tuple[Ec2InstanceProvider, Ec2SandboxEnvironmentConfig]:
+        """Return the provider to use plus the config it should consume.
+
+        Custom provider, if registered, takes precedence. Otherwise build
+        a :class:`DefaultEc2InstanceProvider` from ``config`` (or from
+        environment settings when ``config`` is ``None``).
+        """
+        registered = get_ec2_instance_provider()
+        if isinstance(config, Ec2SandboxEnvironmentConfig):
+            resolved_config = config
+        elif config is None:
+            resolved_config = (
+                Ec2SandboxEnvironmentConfig()
+                if registered is not None
+                else Ec2SandboxEnvironmentConfig.from_settings(
+                    session=cls._get_session()
+                )
+            )
+        else:
+            raise ValueError("config must be a Ec2SandboxEnvironmentConfig")
+
+        if registered is not None:
+            return registered, resolved_config
+        return (
+            DefaultEc2InstanceProvider(resolved_config, cls._get_session()),
+            resolved_config,
+        )
+
+    @classmethod
     @override
     async def sample_init(
         cls,
@@ -125,91 +140,37 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         config: SandboxEnvironmentConfigType | None,
         metadata: dict[str, str],
     ) -> dict[str, SandboxEnvironment]:
-        provider = get_ec2_instance_provider()
+        provider, resolved = cls._resolve_provider(config)
 
-        # Base tags shared by both the custom-provider and default paths.
-        # Each path prepends config.extra_tags in its own way.
-        tags = [
+        tags: list[tuple[str, str]] = list(resolved.extra_tags) + [
             ("Name", f"inspect_ec2_sandbox_{task_name}"),
             ("inspect_task", task_name),
             (MARKER_TAG_KEY, "true"),
         ]
 
-        if provider is not None:
-            # Custom provider path — provider handles all provisioning.
-            instance_type = (
-                config.instance_type
-                if isinstance(config, Ec2SandboxEnvironmentConfig)
-                else "t3a.large"
-            )
-            ami_id = (
-                config.ami_id
-                if isinstance(config, Ec2SandboxEnvironmentConfig)
-                else ""
-            )
-            if isinstance(config, Ec2SandboxEnvironmentConfig) and config.extra_tags:
-                tags = list(config.extra_tags) + tags
-
-            cls.logger.debug(
-                "sample_init: custom provider, type=%s ami=%s",
-                instance_type,
-                ami_id,
-            )
-            result = await provider.create_instance(
-                instance_type=instance_type,
-                ami_id=ami_id,
-                tags=tags,
-            )
-            cls.logger.debug(
-                "sample_init: provider returned id=%s region=%s",
-                result.instance_id,
-                result.region,
-            )
-            environment = Ec2SandboxEnvironment(
-                instance_id=result.instance_id,
-                region=result.region,
-                s3_bucket=result.s3_bucket,
-                s3_key_prefix=result.s3_key_prefix,
-            )
-            return {"default": environment}
-
-        # Default path — direct EC2/SSM calls using Ec2SandboxEnvironmentConfig.
-        session = cls._get_session()
-        if config is None:
-            config = Ec2SandboxEnvironmentConfig.from_settings(session=session)
-        if not isinstance(config, Ec2SandboxEnvironmentConfig):
-            raise ValueError("config must be a Ec2SandboxEnvironmentConfig")
-
-        ec2_client = session.client("ec2", region_name=config.region)
-
-        tags = list(config.extra_tags) + tags
-
-        instance_params = {
-            "ImageId": config.ami_id,
-            "InstanceType": config.instance_type,
-            "SecurityGroupIds": [config.security_group_id],
-            "SubnetId": config.subnet_id,
-            "TagSpecifications": convert_tags_for_aws_interface(
-                "instance", tuple(tags)
-            ),
-            "IamInstanceProfile": {"Name": config.instance_profile},
-        }
-
-        response = ec2_client.run_instances(**instance_params, MinCount=1, MaxCount=1)
-
-        instance = response["Instances"][0]
-        waiter = ec2_client.get_waiter("instance_running")
-        waiter.wait(InstanceIds=[instance["InstanceId"]])
-
-        environment = Ec2SandboxEnvironment(
-            instance_id=instance["InstanceId"],
-            region=config.region,
-            s3_bucket=config.s3_bucket,
-            s3_key_prefix=config.s3_key_prefix,
+        cls.logger.debug(
+            "sample_init: provider=%s type=%s ami=%s",
+            type(provider).__name__,
+            resolved.instance_type,
+            resolved.ami_id,
+        )
+        result = await provider.create_instance(
+            instance_type=resolved.instance_type,
+            ami_id=resolved.ami_id,
+            tags=tags,
+        )
+        cls.logger.debug(
+            "sample_init: provider returned id=%s region=%s",
+            result.instance_id,
+            result.region,
         )
 
-        _wait_for_ssm(environment.instance_id, environment.ssm_client)
-
+        environment = Ec2SandboxEnvironment(
+            instance_id=result.instance_id,
+            region=result.region,
+            s3_bucket=result.s3_bucket,
+            s3_key_prefix=result.s3_key_prefix,
+        )
         return {"default": environment}
 
     @classmethod
@@ -221,16 +182,23 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         environments: Dict[str, SandboxEnvironment],
         interrupted: bool,
     ) -> None:
-        if not interrupted:
-            provider = get_ec2_instance_provider()
-            for env in environments.values():
-                if isinstance(env, Ec2SandboxEnvironment):
-                    if provider is not None:
-                        await provider.terminate_instance(env.instance_id, env.region)
-                    else:
-                        env.ec2_client.terminate_instances(
-                            InstanceIds=[env.instance_id]
-                        )
+        if interrupted:
+            return None
+
+        # Cleanup only needs terminate_instance, which doesn't depend on
+        # the direct-EC2 infra fields. A minimal default config is fine
+        # when none was supplied.
+        registered = get_ec2_instance_provider()
+        if registered is not None:
+            provider: Ec2InstanceProvider = registered
+        else:
+            provider = DefaultEc2InstanceProvider(
+                Ec2SandboxEnvironmentConfig(), cls._get_session()
+            )
+
+        for env in environments.values():
+            if isinstance(env, Ec2SandboxEnvironment):
+                await provider.terminate_instance(env.instance_id, env.region)
         return None
 
     @classmethod
@@ -254,22 +222,36 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         timeout: int | None = None,
         timeout_retry: bool = True,
     ) -> ExecResult[str]:
-        if input is not None:
-            self.logger.warning("Input parameter not supported by EC2 sandbox")
+        inner: list[str] = []
 
-        if user is not None:
-            self.logger.warning("User parameter not supported by EC2 sandbox")
-
-        commands = []
-
-        commands.extend(
+        inner.extend(
             [f"export {shlex.quote(k)}={shlex.quote(v)}" for k, v in env.items()]
         )
 
         if cwd is not None:
-            commands.append(f"cd {shlex.quote(cwd)}")
+            inner.append(f"cd {shlex.quote(cwd)}")
 
-        commands.append(shlex.join(cmd))
+        if input is None:
+            inner.append(shlex.join(cmd))
+        else:
+            input_bytes = input.encode("utf-8") if isinstance(input, str) else input
+            input_b64 = base64.b64encode(input_bytes).decode("ascii")
+            inner.append(
+                f"printf %s {shlex.quote(input_b64)} | base64 -d | {shlex.join(cmd)}"
+            )
+
+        if user is None:
+            commands = inner
+        else:
+            # Run the inner script as `user`. A heredoc with a quoted marker
+            # avoids having to re-quote the whole script for `su -c`.
+            heredoc_suffix = "".join(random.choices(string.ascii_uppercase, k=8))
+            heredoc = f"EOF_EC2SB_{heredoc_suffix}"
+            commands = [
+                f"su -l {shlex.quote(user)} -s /bin/bash << '{heredoc}'",
+                *inner,
+                heredoc,
+            ]
 
         params: dict[str, Any] = {
             "commands": commands,
@@ -285,25 +267,21 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     @classmethod
     @override
     async def cli_cleanup(cls, id: str | None) -> None:
-        if id is None:
-            provider = get_ec2_instance_provider()
-
-            if provider is not None:
-                region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", ""))
-                sandbox_infos = await provider.find_sandbox_instances(region)
-                await cls._cli_cleanup_provider(provider, sandbox_infos, region)
-            else:
-                await cls._cli_cleanup_default()
-        else:
+        if id is not None:
             print("\n[red]Cleanup by ID not implemented[/red]\n")
+            return
 
-    @classmethod
-    async def _cli_cleanup_provider(
-        cls,
-        provider: "Ec2InstanceProvider",
-        instances: list[SandboxInstanceInfo],
-        fallback_region: str,
-    ) -> None:
+        registered = get_ec2_instance_provider()
+        if registered is not None:
+            provider: Ec2InstanceProvider = registered
+        else:
+            provider = DefaultEc2InstanceProvider(
+                Ec2SandboxEnvironmentConfig(), cls._get_session()
+            )
+
+        fallback_region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", ""))
+        instances = await provider.find_sandbox_instances(fallback_region)
+
         if not instances:
             print("\nNo EC2 sandbox instances found to clean up.\n")
             return
@@ -324,57 +302,6 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         for inst in instances:
             region = inst.region or fallback_region
             await provider.terminate_instance(inst.instance_id, region)
-
-    @classmethod
-    async def _cli_cleanup_default(cls) -> None:
-        ec2 = cls._get_session().client("ec2")
-        response = ec2.describe_instances(
-            Filters=[
-                {
-                    "Name": f"tag:{MARKER_TAG_KEY}",
-                    "Values": ["true"],
-                },
-                {
-                    "Name": "instance-state-name",
-                    "Values": [
-                        "pending",
-                        "running",
-                        "stopping",
-                        "stopped",
-                    ],
-                },
-            ]
-        )
-        instances = []
-        for reservation in response["Reservations"]:
-            for instance in reservation["Instances"]:
-                instances.append(instance)
-
-        if not instances:
-            print("\nNo EC2 sandbox instances found to clean up.\n")
-            return
-
-        vms_table = Table(
-            box=box.SQUARE, show_lines=False,
-            title_style="bold", title_justify="left",
-        )
-        vms_table.add_column("Instance ID")
-        vms_table.add_column("Instance Name")
-        for instance in instances:
-            name_tag = ""
-            if "Tags" in instance:
-                for tag in instance["Tags"]:
-                    if tag["Key"] == "Name":
-                        name_tag = tag["Value"]
-                        break
-            vms_table.add_row(instance["InstanceId"], name_tag)
-        print(vms_table)
-
-        if not cls._confirm_cleanup():
-            return
-
-        instance_ids = [inst["InstanceId"] for inst in instances]
-        ec2.terminate_instances(InstanceIds=instance_ids)
 
     @staticmethod
     def _confirm_cleanup() -> bool:

--- a/src/ec2sandbox/_instance_provider.py
+++ b/src/ec2sandbox/_instance_provider.py
@@ -1,12 +1,13 @@
 """Protocol and registry for EC2 instance lifecycle management.
 
 The EC2 sandbox provider delegates instance creation, termination, and
-discovery to an ``Ec2InstanceProvider``.  By default no custom provider
-is registered and the sandbox falls back to direct boto3 EC2/SSM calls.
+discovery to an ``Ec2InstanceProvider``. When no custom provider is
+registered, :class:`DefaultEc2InstanceProvider` is used, which calls
+EC2 and SSM directly via boto3.
 
 External packages (e.g. an organisational wrapper that routes through a
 Lambda or other control plane) can register an alternative provider at
-import time via :func:`set_ec2_instance_provider`.  The Inspect entry-
+import time via :func:`set_ec2_instance_provider`. The Inspect entry-
 point mechanism ensures that such packages are imported before the
 sandbox is used.
 """
@@ -15,12 +16,23 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import boto3
+from botocore.exceptions import ClientError  # noqa: F401  (re-exported for convenience)
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from ._unpack_tags import convert_tags_for_aws_interface
 
 if TYPE_CHECKING:
-    import boto3
+    from .schema import Ec2SandboxEnvironmentConfig
 
 _logger = logging.getLogger(__name__)
+
+
+# Tag applied to every EC2 instance the sandbox provisions, so that the
+# default provider's ``find_sandbox_instances`` can discover them.
+MARKER_TAG_KEY = "inspect_sandbox"
 
 
 @dataclass
@@ -110,7 +122,7 @@ def set_ec2_instance_provider(provider: Ec2InstanceProvider) -> None:
 
 
 def get_ec2_instance_provider() -> Ec2InstanceProvider | None:
-    """Return the registered provider, or ``None`` for the default path."""
+    """Return the registered custom provider, or ``None`` for the default."""
     return _provider
 
 
@@ -133,3 +145,137 @@ def get_provider_session(
     if get_session is None:
         return None
     return get_session()
+
+
+# ---------------------------------------------------------------------------
+# Default direct-EC2 provider
+# ---------------------------------------------------------------------------
+
+
+@retry(stop=stop_after_attempt(20), wait=wait_fixed(30))
+def _wait_for_ssm(instance_id: str, ssm_client: Any) -> bool:
+    """Wait for SSM agent to come online on the given instance."""
+    resp = ssm_client.describe_instance_information(
+        InstanceInformationFilterList=[
+            {"key": "InstanceIds", "valueSet": [instance_id]}
+        ]
+    )
+    if (
+        not resp["InstanceInformationList"]
+        or resp["InstanceInformationList"][0]["PingStatus"] != "Online"
+    ):
+        raise Exception("Not ready")
+    return True
+
+
+class DefaultEc2InstanceProvider:
+    """Default :class:`Ec2InstanceProvider` using direct boto3 calls.
+
+    Used by the EC2 sandbox when no custom provider has been registered.
+    Reads the infrastructure fields (``region``, ``security_group_id``,
+    etc.) from the supplied :class:`Ec2SandboxEnvironmentConfig` at the
+    point they are needed — ``create_instance`` requires the full set,
+    while ``terminate_instance`` and ``find_sandbox_instances`` only
+    need the supplied ``region``.
+    """
+
+    def __init__(
+        self,
+        config: "Ec2SandboxEnvironmentConfig",
+        session: boto3.Session,
+    ) -> None:
+        self._config = config
+        self._session = session
+
+    def get_session(self) -> boto3.Session:
+        return self._session
+
+    async def create_instance(
+        self,
+        instance_type: str,
+        ami_id: str,
+        tags: list[tuple[str, str]],
+    ) -> ProvisionedInstance:
+        cfg = self._config
+        required = {
+            "region": cfg.region,
+            "security_group_id": cfg.security_group_id,
+            "subnet_id": cfg.subnet_id,
+            "instance_profile": cfg.instance_profile,
+            "s3_bucket": cfg.s3_bucket,
+            "ami_id": ami_id,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(
+                "Ec2SandboxEnvironmentConfig is missing fields required by "
+                f"the default EC2 instance provider: {', '.join(missing)}. "
+                "Either populate them (typically via from_settings) or "
+                "register an Ec2InstanceProvider."
+            )
+
+        ec2_client = self._session.client("ec2", region_name=cfg.region)
+        instance_params = {
+            "ImageId": ami_id,
+            "InstanceType": instance_type,
+            "SecurityGroupIds": [cfg.security_group_id],
+            "SubnetId": cfg.subnet_id,
+            "TagSpecifications": convert_tags_for_aws_interface(
+                "instance", tuple(tags)
+            ),
+            "IamInstanceProfile": {"Name": cfg.instance_profile},
+        }
+        response = ec2_client.run_instances(
+            **instance_params, MinCount=1, MaxCount=1
+        )
+        instance = response["Instances"][0]
+        instance_id = instance["InstanceId"]
+
+        waiter = ec2_client.get_waiter("instance_running")
+        waiter.wait(InstanceIds=[instance_id])
+
+        ssm_client = self._session.client("ssm", region_name=cfg.region)
+        _wait_for_ssm(instance_id, ssm_client)
+
+        assert cfg.region is not None  # validated above
+        assert cfg.s3_bucket is not None  # validated above
+        return ProvisionedInstance(
+            instance_id=instance_id,
+            region=cfg.region,
+            s3_bucket=cfg.s3_bucket,
+            s3_key_prefix=cfg.s3_key_prefix,
+        )
+
+    async def terminate_instance(self, instance_id: str, region: str) -> None:
+        ec2 = self._session.client("ec2", region_name=region or None)
+        ec2.terminate_instances(InstanceIds=[instance_id])
+
+    async def find_sandbox_instances(
+        self, region: str
+    ) -> list[SandboxInstanceInfo]:
+        ec2 = self._session.client("ec2", region_name=region or None)
+        response = ec2.describe_instances(
+            Filters=[
+                {"Name": f"tag:{MARKER_TAG_KEY}", "Values": ["true"]},
+                {
+                    "Name": "instance-state-name",
+                    "Values": ["pending", "running", "stopping", "stopped"],
+                },
+            ]
+        )
+        results: list[SandboxInstanceInfo] = []
+        for reservation in response["Reservations"]:
+            for instance in reservation["Instances"]:
+                name = ""
+                for tag in instance.get("Tags", []):
+                    if tag["Key"] == "Name":
+                        name = tag["Value"]
+                        break
+                results.append(
+                    SandboxInstanceInfo(
+                        instance_id=instance["InstanceId"],
+                        name=name,
+                        region=region,
+                    )
+                )
+        return results

--- a/src/ec2sandbox/schema.py
+++ b/src/ec2sandbox/schema.py
@@ -53,16 +53,23 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
         extra_tags: tuple of 2-tuples of additional tags
     """
 
-    region: str
-    vpc_id: str  # TODO is this actually needed, we could just force a subnet ID
-    security_group_id: str
-    subnet_id: str
-    ami_id: str
-    instance_type: str
-    instance_profile: str
-    s3_bucket: str
-    s3_key_prefix: str
-    extra_tags: Tuple[Tuple[str, str], ...]
+    # Shared fields — used by both the direct-EC2 path and any custom
+    # Ec2InstanceProvider. Have sensible defaults.
+    instance_type: str = "t3a.large"
+    ami_id: str = ""  # empty -> provider chooses or from_settings resolves
+    extra_tags: Tuple[Tuple[str, str], ...] = ()
+    s3_key_prefix: str = ""
+
+    # Direct-EC2-path fields — required when no Ec2InstanceProvider is
+    # registered, ignored otherwise. ``sample_init`` validates these at
+    # call time when the direct path is taken.
+    region: Optional[str] = None
+    # TODO is vpc_id actually needed? We could just force a subnet ID.
+    vpc_id: Optional[str] = None
+    security_group_id: Optional[str] = None
+    subnet_id: Optional[str] = None
+    instance_profile: Optional[str] = None
+    s3_bucket: Optional[str] = None
 
     @classmethod
     def from_settings(cls, session: "boto3.Session | None" = None, **kwargs):

--- a/tests/ec2sandboxtest/test_cleanup.py
+++ b/tests/ec2sandboxtest/test_cleanup.py
@@ -1,4 +1,5 @@
 import asyncio
+from importlib.metadata import entry_points
 from typing import Tuple
 
 import boto3
@@ -9,6 +10,7 @@ from ec2sandbox._ec2_sandbox_environment import (
     Ec2SandboxEnvironment,
     Ec2SandboxEnvironmentConfig,
 )
+from ec2sandbox._instance_provider import get_ec2_instance_provider
 
 
 async def test_cleanup():
@@ -53,7 +55,17 @@ async def test_cli_cleanup() -> None:
 async def _create_environment(
     task_name: str,
 ) -> Tuple[Ec2SandboxEnvironmentConfig, dict[str, SandboxEnvironment], str]:
-    config = Ec2SandboxEnvironmentConfig.from_settings(instance_type="t3a.micro")
+    # Load inspect_ai entry points so any registered Ec2InstanceProvider
+    # (e.g. aisi-inspect-tools' Lambda-backed provider) is installed.
+    # inspect_ai.eval() does this itself, but these tests bypass eval().
+    for ep in entry_points(group="inspect_ai"):
+        ep.load()
+
+    config = (
+        Ec2SandboxEnvironmentConfig(instance_type="t3a.micro")
+        if get_ec2_instance_provider() is not None
+        else Ec2SandboxEnvironmentConfig.from_settings(instance_type="t3a.micro")
+    )
 
     envs = await Ec2SandboxEnvironment.sample_init(
         task_name=task_name,

--- a/tests/ec2sandboxtest/test_eval.py
+++ b/tests/ec2sandboxtest/test_eval.py
@@ -39,7 +39,7 @@ def test_inspect_eval() -> None:
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
                     tool_name="bash",
-                    tool_arguments={"cmd": "uname -a"},
+                    tool_arguments={"command": "uname -a"},
                 ),
                 ModelOutput.for_tool_call(
                     model="mockllm/model",

--- a/tests/ec2sandboxtest/test_sandbox_self_check.py
+++ b/tests/ec2sandboxtest/test_sandbox_self_check.py
@@ -1,29 +1,32 @@
 import hashlib
 import subprocess
+from importlib.metadata import entry_points
 from typing import AsyncGenerator, List
 
 import pytest
 from inspect_ai.util._sandbox.self_check import self_check
 
 from ec2sandbox._ec2_sandbox_environment import Ec2SandboxEnvironment
-from ec2sandbox.schema import Ec2SandboxEnvironmentConfig
 
 
 @pytest.fixture
 async def ec2_sandbox_environment() -> AsyncGenerator[Ec2SandboxEnvironment, None]:
-    config = Ec2SandboxEnvironmentConfig.from_settings()
+    # Load inspect_ai entry points so any registered Ec2InstanceProvider is installed.
+    # inspect_ai.eval() does this itself, but this test bypasses eval().
+    for ep in entry_points(group="inspect_ai"):
+        ep.load()
+
     task_name = "unit_test"
     envs = await Ec2SandboxEnvironment.sample_init(
         task_name=task_name,
-        config=config,
+        config=None,
         metadata={},
     )
     assert "default" in envs
     assert isinstance(envs["default"], Ec2SandboxEnvironment)
-    sandbox_environment = envs["default"]
-    yield sandbox_environment
+    yield envs["default"]
     await Ec2SandboxEnvironment.sample_cleanup(
-        task_name=task_name, config=config, environments=envs, interrupted=False
+        task_name=task_name, config=None, environments=envs, interrupted=False
     )
 
 
@@ -57,10 +60,11 @@ async def test_self_check(ec2_sandbox_environment) -> None:
     known_failures: List[str] = [
         # Tests that are never going to pass due to how SSM works:
         "test_read_file_not_allowed",  # user is root, so this doesn't work
-        "test_exec_as_user",  # unsupported
-        "test_exec_as_nonexistent_user",  # unsupported
         "test_write_text_file_without_permissions",  # user is root
         "test_write_binary_file_without_permissions",  # user is root
+        "test_exec_timeout",  # cancel_command requires ssm:CancelCommand
+        "test_exec_stdout_is_limited",  # SSM truncates large output before S3 upload
+        "test_exec_stderr_is_limited",  # SSM truncates large output before S3 upload
     ]
 
     return await check_results_of_self_check(ec2_sandbox_environment, known_failures)


### PR DESCRIPTION

- Forward `exec()` input param to command stdin
- Support `exec` as user
- Refactor direct-EC2 path into `DefaultEc2InstanceProvider`
