### PR TITLE
Add volume_size to Ec2SandboxEnvironmentConfig and provider protocol

### DIFF
--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -154,10 +154,18 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             resolved.instance_type,
             resolved.ami_id,
         )
+        # Pass volume_size only when set, so providers that pre-date this
+        # parameter keep working unchanged. A caller that sets volume_size
+        # against such a provider will get a clear TypeError pointing at
+        # the unsupported kwarg.
+        extra: dict[str, Any] = {}
+        if resolved.volume_size is not None:
+            extra["volume_size"] = resolved.volume_size
         result = await provider.create_instance(
             instance_type=resolved.instance_type,
             ami_id=resolved.ami_id,
             tags=tags,
+            **extra,
         )
         cls.logger.debug(
             "sample_init: provider returned id=%s region=%s",

--- a/src/ec2sandbox/_instance_provider.py
+++ b/src/ec2sandbox/_instance_provider.py
@@ -74,6 +74,7 @@ class Ec2InstanceProvider(Protocol):
         instance_type: str,
         ami_id: str,
         tags: list[tuple[str, str]],
+        volume_size: int | None = None,
     ) -> ProvisionedInstance:
         """Create an EC2 instance and wait until it is SSM-ready.
 
@@ -82,6 +83,8 @@ class Ec2InstanceProvider(Protocol):
             ami_id: AMI to launch.  May be empty if the provider
                 resolves its own AMI.
             tags: Key/value pairs to apply to the instance.
+            volume_size: Optional override (GiB) for the root EBS
+                volume size. ``None`` keeps the AMI's baked-in size.
 
         Returns:
             A :class:`ProvisionedInstance` with the runtime config
@@ -152,6 +155,15 @@ def get_provider_session(
 # ---------------------------------------------------------------------------
 
 
+def _root_device_name(ec2_client: Any, ami_id: str) -> str:
+    """Return the root device name (e.g. ``/dev/sda1``) for ``ami_id``."""
+    resp = ec2_client.describe_images(ImageIds=[ami_id])
+    images = resp.get("Images", [])
+    if not images:
+        raise ValueError(f"AMI {ami_id} not found when resolving root device name")
+    return images[0]["RootDeviceName"]
+
+
 @retry(stop=stop_after_attempt(20), wait=wait_fixed(30))
 def _wait_for_ssm(instance_id: str, ssm_client: Any) -> bool:
     """Wait for SSM agent to come online on the given instance."""
@@ -195,6 +207,7 @@ class DefaultEc2InstanceProvider:
         instance_type: str,
         ami_id: str,
         tags: list[tuple[str, str]],
+        volume_size: int | None = None,
     ) -> ProvisionedInstance:
         cfg = self._config
         required = {
@@ -215,7 +228,7 @@ class DefaultEc2InstanceProvider:
             )
 
         ec2_client = self._session.client("ec2", region_name=cfg.region)
-        instance_params = {
+        instance_params: dict[str, Any] = {
             "ImageId": ami_id,
             "InstanceType": instance_type,
             "SecurityGroupIds": [cfg.security_group_id],
@@ -225,6 +238,13 @@ class DefaultEc2InstanceProvider:
             ),
             "IamInstanceProfile": {"Name": cfg.instance_profile},
         }
+        if volume_size is not None:
+            instance_params["BlockDeviceMappings"] = [
+                {
+                    "DeviceName": _root_device_name(ec2_client, ami_id),
+                    "Ebs": {"VolumeSize": volume_size},
+                }
+            ]
         response = ec2_client.run_instances(
             **instance_params, MinCount=1, MaxCount=1
         )

--- a/src/ec2sandbox/schema.py
+++ b/src/ec2sandbox/schema.py
@@ -51,6 +51,8 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
             Useful if you want to constrain the sandbox
             to a specific folder in the bucket
         extra_tags: tuple of 2-tuples of additional tags
+        volume_size: Root EBS volume size in GiB (optional). If None, the
+            AMI's baked-in size is used.
     """
 
     # Shared fields — used by both the direct-EC2 path and any custom
@@ -59,6 +61,7 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
     ami_id: str = ""  # empty -> provider chooses or from_settings resolves
     extra_tags: Tuple[Tuple[str, str], ...] = ()
     s3_key_prefix: str = ""
+    volume_size: Optional[int] = None
 
     # Direct-EC2-path fields — required when no Ec2InstanceProvider is
     # registered, ignored otherwise. ``sample_init`` validates these at

--- a/tests/ec2sandboxtest/test_cleanup.py
+++ b/tests/ec2sandboxtest/test_cleanup.py
@@ -69,7 +69,7 @@ async def test_volume_size_override() -> None:
         script = (
             "set -e; "
             "root_part=$(findmnt -no SOURCE /); "
-            "disk=$(lsblk -no PKNAME \"$root_part\"); "
+            'disk=$(lsblk -no PKNAME "$root_part"); '
             'sectors=$(cat /sys/block/"$disk"/size); '
             "echo $((sectors / 2097152))"
         )

--- a/tests/ec2sandboxtest/test_cleanup.py
+++ b/tests/ec2sandboxtest/test_cleanup.py
@@ -52,8 +52,46 @@ async def test_cli_cleanup() -> None:
     assert new_instance_id not in post_cleanup_instance_ids
 
 
+async def test_volume_size_override() -> None:
+    # Pick a size that's distinct from any provider default and from the
+    # AMI's baked-in size, so the override is observable end-to-end.
+    requested_size = 220
+    config, envs, _ = await _create_environment(
+        task_name="test_volume_size_override",
+        volume_size=requested_size,
+    )
+
+    try:
+        env = envs["default"]
+        assert isinstance(env, Ec2SandboxEnvironment)
+        # findmnt → root partition, PKNAME → parent disk, /sys/block/<d>/size
+        # is in 512-byte sectors. Divide by 2**21 to convert to GiB.
+        script = (
+            "set -e; "
+            "root_part=$(findmnt -no SOURCE /); "
+            "disk=$(lsblk -no PKNAME \"$root_part\"); "
+            'sectors=$(cat /sys/block/"$disk"/size); '
+            "echo $((sectors / 2097152))"
+        )
+        result = await env.exec(["bash", "-c", script], timeout=60)
+        assert result.success, f"failed to inspect disk size: {result.stderr}"
+        observed_gib = int(result.stdout.strip())
+        assert observed_gib == requested_size, (
+            f"Expected root disk of {requested_size} GiB, observed {observed_gib} "
+            f"GiB (stdout={result.stdout!r})"
+        )
+    finally:
+        await Ec2SandboxEnvironment.sample_cleanup(
+            task_name="test_volume_size_override",
+            config=config,
+            environments=envs,
+            interrupted=False,
+        )
+
+
 async def _create_environment(
     task_name: str,
+    volume_size: int | None = None,
 ) -> Tuple[Ec2SandboxEnvironmentConfig, dict[str, SandboxEnvironment], str]:
     # Load inspect_ai entry points so any registered Ec2InstanceProvider
     # (e.g. aisi-inspect-tools' Lambda-backed provider) is installed.
@@ -61,10 +99,14 @@ async def _create_environment(
     for ep in entry_points(group="inspect_ai"):
         ep.load()
 
+    overrides: dict[str, object] = {"instance_type": "t3a.micro"}
+    if volume_size is not None:
+        overrides["volume_size"] = volume_size
+
     config = (
-        Ec2SandboxEnvironmentConfig(instance_type="t3a.micro")
+        Ec2SandboxEnvironmentConfig(**overrides)
         if get_ec2_instance_provider() is not None
-        else Ec2SandboxEnvironmentConfig.from_settings(instance_type="t3a.micro")
+        else Ec2SandboxEnvironmentConfig.from_settings(**overrides)
     )
 
     envs = await Ec2SandboxEnvironment.sample_init(

--- a/tests/ec2sandboxtest/test_instance_provider.py
+++ b/tests/ec2sandboxtest/test_instance_provider.py
@@ -1,0 +1,124 @@
+from unittest import mock
+
+import pytest
+
+from ec2sandbox._instance_provider import DefaultEc2InstanceProvider
+from ec2sandbox.schema import Ec2SandboxEnvironmentConfig
+
+
+def _make_config(**overrides) -> Ec2SandboxEnvironmentConfig:
+    defaults = dict(
+        instance_type="t3a.micro",
+        ami_id="ami-123",
+        region="eu-west-2",
+        security_group_id="sg-1",
+        subnet_id="subnet-1",
+        instance_profile="profile-1",
+        s3_bucket="bucket-1",
+    )
+    defaults.update(overrides)
+    return Ec2SandboxEnvironmentConfig(**defaults)
+
+
+def _make_provider_with_mocks(config):
+    ec2_client = mock.MagicMock()
+    ec2_client.run_instances.return_value = {
+        "Instances": [{"InstanceId": "i-abc"}]
+    }
+    ec2_client.describe_images.return_value = {
+        "Images": [{"RootDeviceName": "/dev/sda1"}]
+    }
+    waiter = mock.MagicMock()
+    ec2_client.get_waiter.return_value = waiter
+
+    ssm_client = mock.MagicMock()
+    ssm_client.describe_instance_information.return_value = {
+        "InstanceInformationList": [{"PingStatus": "Online"}]
+    }
+
+    def client(service, **kwargs):
+        if service == "ec2":
+            return ec2_client
+        if service == "ssm":
+            return ssm_client
+        raise AssertionError(f"unexpected client: {service}")
+
+    session = mock.MagicMock()
+    session.client.side_effect = client
+
+    return DefaultEc2InstanceProvider(config, session), ec2_client
+
+
+@pytest.mark.asyncio
+async def test_create_instance_no_volume_size_omits_block_device_mappings():
+    provider, ec2_client = _make_provider_with_mocks(_make_config())
+
+    await provider.create_instance(
+        instance_type="t3a.micro",
+        ami_id="ami-123",
+        tags=[("Name", "x")],
+    )
+
+    kwargs = ec2_client.run_instances.call_args.kwargs
+    assert "BlockDeviceMappings" not in kwargs
+    ec2_client.describe_images.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_instance_with_volume_size_sets_block_device_mappings():
+    provider, ec2_client = _make_provider_with_mocks(
+        _make_config(volume_size=100)
+    )
+
+    await provider.create_instance(
+        instance_type="t3a.micro",
+        ami_id="ami-123",
+        tags=[("Name", "x")],
+        volume_size=100,
+    )
+
+    kwargs = ec2_client.run_instances.call_args.kwargs
+    assert kwargs["BlockDeviceMappings"] == [
+        {"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 100}}
+    ]
+    ec2_client.describe_images.assert_called_once_with(ImageIds=["ami-123"])
+
+
+async def _call_sample_init(config):
+    from ec2sandbox._ec2_sandbox_environment import Ec2SandboxEnvironment
+    from ec2sandbox._instance_provider import ProvisionedInstance
+
+    fake_provider = mock.MagicMock()
+
+    async def create_instance(**kwargs):
+        create_instance.kwargs = kwargs
+        return ProvisionedInstance(
+            instance_id="i-xyz",
+            region="eu-west-2",
+            s3_bucket="bucket-1",
+        )
+
+    fake_provider.create_instance = create_instance
+
+    with mock.patch(
+        "ec2sandbox._ec2_sandbox_environment.get_ec2_instance_provider",
+        return_value=fake_provider,
+    ):
+        await Ec2SandboxEnvironment.sample_init(
+            task_name="t", config=config, metadata={}
+        )
+    return create_instance.kwargs
+
+
+@pytest.mark.asyncio
+async def test_sample_init_passes_volume_size_to_provider():
+    kwargs = await _call_sample_init(_make_config(volume_size=200))
+    assert kwargs["volume_size"] == 200
+
+
+@pytest.mark.asyncio
+async def test_sample_init_omits_volume_size_when_unset():
+    # Providers that pre-date the volume_size parameter must keep working,
+    # so sample_init must not pass the kwarg at all when it is None.
+    kwargs = await _call_sample_init(_make_config())
+    assert "volume_size" not in kwargs

--- a/tests/ec2sandboxtest/test_instance_provider.py
+++ b/tests/ec2sandboxtest/test_instance_provider.py
@@ -22,9 +22,7 @@ def _make_config(**overrides) -> Ec2SandboxEnvironmentConfig:
 
 def _make_provider_with_mocks(config):
     ec2_client = mock.MagicMock()
-    ec2_client.run_instances.return_value = {
-        "Instances": [{"InstanceId": "i-abc"}]
-    }
+    ec2_client.run_instances.return_value = {"Instances": [{"InstanceId": "i-abc"}]}
     ec2_client.describe_images.return_value = {
         "Images": [{"RootDeviceName": "/dev/sda1"}]
     }
@@ -66,9 +64,7 @@ async def test_create_instance_no_volume_size_omits_block_device_mappings():
 
 @pytest.mark.asyncio
 async def test_create_instance_with_volume_size_sets_block_device_mappings():
-    provider, ec2_client = _make_provider_with_mocks(
-        _make_config(volume_size=100)
-    )
+    provider, ec2_client = _make_provider_with_mocks(_make_config(volume_size=100))
 
     await provider.create_instance(
         instance_type="t3a.micro",


### PR DESCRIPTION
## Summary

Closes #9.

Adds an optional `volume_size` (GiB) to `Ec2SandboxEnvironmentConfig` and threads it through `Ec2InstanceProvider.create_instance`, so evals can configure a larger root volume per-task instead of baking a new AMI.
