### PR TITLE
Terminate instances in sample_cleanup when interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+- terminate instances in `sample_cleanup` even when `interrupted=True`, so
+  setup-script failures and Ctrl-C don't leave instances running
 - remove --fail-with-body from curl to support older versions

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -190,9 +190,6 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         environments: Dict[str, SandboxEnvironment],
         interrupted: bool,
     ) -> None:
-        if interrupted:
-            return None
-
         # Cleanup only needs terminate_instance, which doesn't depend on
         # the direct-EC2 infra fields. A minimal default config is fine
         # when none was supplied.


### PR DESCRIPTION
`sample_cleanup` currently returns early when `interrupted=True`. inspect_ai sets that flag not only on Ctrl-C but also when a sample's setup script fails ([context.py](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/util/_sandbox/context.py) — `init_sandbox_environments_sample` calls `sample_cleanup(..., True)` on any exception). With no `task_cleanup` sweep here, those instances stay running until a manual `inspect sandbox cleanup ec2`.

This PR removes the early return so instances are always terminated.

**User-visible change:** an instance is no longer left running after Ctrl-C or a setup failure. To keep one for debugging, pass `--no-sandbox-cleanup`.