### PR TITLE
feat(ci): add PyPI publish workflow — closes #13

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish-release:
+        description: "Production Release"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    strategy:
+      fail-fast: false
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build
+        run: python -m build
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ ! inputs.publish-release }}
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ inputs.publish-release }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,26 @@ manually:
 ```bash
 mypy
 ```
+
+## Releasing to PyPI
+
+Releases are published to PyPI via the [Publish to PyPI](.github/workflows/pypi.yml)
+workflow, which is triggered manually (`workflow_dispatch`) and uses PyPI's [trusted
+publisher](https://docs.pypi.org/trusted-publishers/) OIDC flow (no API token in the
+repository).
+
+To cut a release:
+
+1. Update `version` in `pyproject.toml` and add an entry to `CHANGELOG.md`.
+2. Open a PR, get it reviewed and merged.
+3. Tag the merge commit on `main` (`git tag v0.X.Y && git push --tags`) and create a
+   GitHub Release pointing at the tag.
+4. Run the **Publish to PyPI** workflow with `publish-release: false` first to push to
+   TestPyPI and sanity-check the artifact.
+5. Re-run the workflow with `publish-release: true` to push to PyPI.
+
+The workflow requires the `pypi` GitHub Environment to be configured on the repository
+and the trusted publisher to be registered for this project on
+[pypi.org](https://pypi.org/manage/account/publishing/) and
+[test.pypi.org](https://test.pypi.org/manage/account/publishing/). These are one-time
+maintainer setup steps.


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered `.github/workflows/pypi.yml` so that releases can be pushed to PyPI without the manual ad-hoc twine flow that produced today's placeholder `0.0.1`.

Closes #13.

## What's in the PR

- **`.github/workflows/pypi.yml`** — copies the pattern used by [`UKGovernmentBEIS/inspect_ai/.github/workflows/pypi.yml`](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.github/workflows/pypi.yml) exactly:
  - `workflow_dispatch` trigger with a `publish-release` boolean input.
  - Builds with `python -m build` (works with the existing `hatchling` backend declared in `pyproject.toml`).
  - Publishes via `pypa/gh-action-pypi-publish@release/v1` using PyPI's [trusted publisher](https://docs.pypi.org/trusted-publishers/) OIDC flow — no API tokens stored in the repo.
  - `publish-release: false` (default) → TestPyPI. `publish-release: true` → production PyPI.
- **`CONTRIBUTING.md`** — new "Releasing to PyPI" section walking through the version bump → tag → release → workflow-dispatch flow, and listing the one-time maintainer setup (trusted publisher registration on both PyPI hosts, plus a `pypi` GitHub Environment on the repo).

## What this does *not* do

- It does not publish anything by itself — the workflow is gated on `workflow_dispatch`. The first run still requires the maintainer to:
  1. Register the trusted publisher for `inspect-ec2-sandbox` on [pypi.org](https://pypi.org/manage/account/publishing/) and [test.pypi.org](https://test.pypi.org/manage/account/publishing/) — the publisher fields are `UKGovernmentBEIS / inspect_ec2_sandbox / .github/workflows/pypi.yml / pypi` (one-time).
  2. Create a `pypi` GitHub Environment under Settings → Environments on this repo (one-time, can be restricted to releases on `main` if desired).
- It does not change the `version` in `pyproject.toml` — that's intentionally a release-time bump rather than a PR change.
- It does not delete the placeholder `0.0.1` from PyPI (only PyPI maintainers can do that; the new release just lands as `0.X.Y` alongside it).

## Why mirror `inspect_ai`'s pypi.yml exactly

It's the canonical pattern across the `UKGovernmentBEIS` org, AISI maintainers will already recognize it, and it intentionally trades automated-on-release for a deliberate manual gate — useful for any GovUK-published package where there's value in a human-in-the-loop before each push.

`inspect_k8s_sandbox` (PyPI v0.5.0) appears to be published manually today; this same workflow could be portable there if useful, but that's a separate PR.

## Verification

The workflow YAML is syntactically valid (lints clean against `actionlint`). The `python -m build` step works locally against this branch's `pyproject.toml` and produces a wheel + sdist that contain the `ec2sandbox` package per the `[tool.hatch.build.targets.wheel]` config.

I haven't been able to test the actual `pypa/gh-action-pypi-publish` step end-to-end without the trusted publisher registered — but it's the same step `inspect_ai` uses in production, so it should work identically once the one-time setup is complete.

cc maintainers familiar with the inspect_* publish chain.