### PR TITLE
Support multiple named sandbox environments per sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- add `sandbox_names` config field to create multiple named EC2 environments per sample (addressable via `sandbox("<name>")`)
 - remove --fail-with-body from curl to support older versions

--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ sandbox=SandboxEnvironmentSpec("ec2", Ec2SandboxEnvironmentConfig.from_settings(
 
 See [schema.py](src/ec2sandbox/schema.py) for details.
 
+### Multiple sandbox environments per sample
+
+By default each sample gets a single environment named `"default"`. To run a
+multi-host topology where environments are addressed separately, set
+`sandbox_names`:
+
+```python
+sandbox=SandboxEnvironmentSpec("ec2", Ec2SandboxEnvironmentConfig.from_settings(
+    ...,
+    sandbox_names=("victim", "attacker"),
+)),
+```
+
+One instance is created per name (concurrently), all symmetric (same
+`instance_type`, `ami_id`, `volume_size`). The first name is the default, so
+`sandbox()` returns `victim` and `sandbox("attacker")` returns the second.
+
 ## Tech Debt / Missing features
 
 - task_cleanup is not implemented; only the default sample_cleanup is, so if you Ctrl-C a run, you have to clean up with the CLI command

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import errno
 import os
@@ -142,18 +143,11 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     ) -> dict[str, SandboxEnvironment]:
         provider, resolved = cls._resolve_provider(config)
 
-        tags: list[tuple[str, str]] = list(resolved.extra_tags) + [
-            ("Name", f"inspect_ec2_sandbox_{task_name}"),
+        base_tags: list[tuple[str, str]] = list(resolved.extra_tags) + [
             ("inspect_task", task_name),
             (MARKER_TAG_KEY, "true"),
         ]
 
-        cls.logger.debug(
-            "sample_init: provider=%s type=%s ami=%s",
-            type(provider).__name__,
-            resolved.instance_type,
-            resolved.ami_id,
-        )
         # Pass volume_size only when set, so providers that pre-date this
         # parameter keep working unchanged. A caller that sets volume_size
         # against such a provider will get a clear TypeError pointing at
@@ -161,25 +155,69 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         extra: dict[str, Any] = {}
         if resolved.volume_size is not None:
             extra["volume_size"] = resolved.volume_size
-        result = await provider.create_instance(
-            instance_type=resolved.instance_type,
-            ami_id=resolved.ami_id,
-            tags=tags,
-            **extra,
-        )
+
+        # Empty sandbox_names keeps the original single-environment behaviour;
+        # the dict key stays "default" and the Name tag is unchanged.
+        names = resolved.sandbox_names or ("default",)
+        multi = bool(resolved.sandbox_names)
+
         cls.logger.debug(
-            "sample_init: provider returned id=%s region=%s",
-            result.instance_id,
-            result.region,
+            "sample_init: provider=%s type=%s ami=%s names=%s",
+            type(provider).__name__,
+            resolved.instance_type,
+            resolved.ami_id,
+            names,
         )
 
-        environment = Ec2SandboxEnvironment(
-            instance_id=result.instance_id,
-            region=result.region,
-            s3_bucket=result.s3_bucket,
-            s3_key_prefix=result.s3_key_prefix,
+        async def create(name: str) -> tuple[str, Ec2SandboxEnvironment]:
+            name_tag = (
+                f"inspect_ec2_sandbox_{task_name}_{name}"
+                if multi
+                else f"inspect_ec2_sandbox_{task_name}"
+            )
+            tags = [("Name", name_tag), *base_tags]
+            result = await provider.create_instance(
+                instance_type=resolved.instance_type,
+                ami_id=resolved.ami_id,
+                tags=tags,
+                **extra,
+            )
+            cls.logger.debug(
+                "sample_init: provider returned name=%s id=%s region=%s",
+                name,
+                result.instance_id,
+                result.region,
+            )
+            return name, Ec2SandboxEnvironment(
+                instance_id=result.instance_id,
+                region=result.region,
+                s3_bucket=result.s3_bucket,
+                s3_key_prefix=result.s3_key_prefix,
+            )
+
+        results = await asyncio.gather(
+            *(create(name) for name in names), return_exceptions=True
         )
-        return {"default": environment}
+
+        # If any instance failed to come up, terminate the ones that did so
+        # they don't leak (sample_cleanup only sees what we return here).
+        succeeded = [r for r in results if not isinstance(r, BaseException)]
+        errors = [r for r in results if isinstance(r, BaseException)]
+        if errors:
+            for _, env in succeeded:
+                try:
+                    await provider.terminate_instance(env.instance_id, env.region)
+                except Exception:
+                    cls.logger.warning(
+                        "Failed to terminate instance %s while rolling back a "
+                        "partial sample_init failure",
+                        env.instance_id,
+                        exc_info=True,
+                    )
+            raise errors[0]
+
+        # dict() preserves order, so names[0] is the default environment.
+        return dict(succeeded)
 
     @classmethod
     @override

--- a/src/ec2sandbox/schema.py
+++ b/src/ec2sandbox/schema.py
@@ -9,7 +9,7 @@ import os
 from typing import Optional, Tuple
 
 import boto3
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ._unpack_tags import unpack_tags
@@ -53,6 +53,12 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
         extra_tags: tuple of 2-tuples of additional tags
         volume_size: Root EBS volume size in GiB (optional). If None, the
             AMI's baked-in size is used.
+        sandbox_names: names of the sandbox environments to create for each
+            sample (optional). When set, one instance is created per name and
+            the environments are addressable via ``sandbox("<name>")``, with
+            the first name as the default. When empty, a single ``"default"``
+            environment is created (the original behaviour). All instances are
+            symmetric (same instance_type, ami_id, volume_size).
     """
 
     # Shared fields — used by both the direct-EC2 path and any custom
@@ -62,6 +68,7 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
     extra_tags: Tuple[Tuple[str, str], ...] = ()
     s3_key_prefix: str = ""
     volume_size: Optional[int] = None
+    sandbox_names: Tuple[str, ...] = ()
 
     # Direct-EC2-path fields — required when no Ec2InstanceProvider is
     # registered, ignored otherwise. ``sample_init`` validates these at
@@ -73,6 +80,15 @@ class Ec2SandboxEnvironmentConfig(BaseModel, frozen=True):
     subnet_id: Optional[str] = None
     instance_profile: Optional[str] = None
     s3_bucket: Optional[str] = None
+
+    @field_validator("sandbox_names")
+    @classmethod
+    def _validate_sandbox_names(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
+        if any(not name for name in value):
+            raise ValueError("sandbox_names must not contain empty strings")
+        if len(set(value)) != len(value):
+            raise ValueError(f"sandbox_names must be unique, got {value}")
+        return value
 
     @classmethod
     def from_settings(cls, session: "boto3.Session | None" = None, **kwargs):

--- a/tests/ec2sandboxtest/test_instance_provider.py
+++ b/tests/ec2sandboxtest/test_instance_provider.py
@@ -118,3 +118,104 @@ async def test_sample_init_omits_volume_size_when_unset():
     # so sample_init must not pass the kwarg at all when it is None.
     kwargs = await _call_sample_init(_make_config())
     assert "volume_size" not in kwargs
+
+
+def _make_recording_provider():
+    """Fake provider: records each create_instance call, distinct id per call."""
+    from ec2sandbox._instance_provider import ProvisionedInstance
+
+    provider = mock.MagicMock()
+    provider.calls = []
+
+    async def create_instance(**kwargs):
+        provider.calls.append(kwargs)
+        return ProvisionedInstance(
+            instance_id=f"i-{len(provider.calls)}",
+            region="eu-west-2",
+            s3_bucket="bucket-1",
+        )
+
+    async def terminate_instance(instance_id, region):
+        provider.terminated.append(instance_id)
+
+    provider.terminated = []
+    provider.create_instance = create_instance
+    provider.terminate_instance = terminate_instance
+    return provider
+
+
+async def _sample_init_with(provider, config):
+    from ec2sandbox._ec2_sandbox_environment import Ec2SandboxEnvironment
+
+    with mock.patch(
+        "ec2sandbox._ec2_sandbox_environment.get_ec2_instance_provider",
+        return_value=provider,
+    ):
+        return await Ec2SandboxEnvironment.sample_init(
+            task_name="t", config=config, metadata={}
+        )
+
+
+@pytest.mark.asyncio
+async def test_sample_init_single_default_when_no_names():
+    provider = _make_recording_provider()
+    envs = await _sample_init_with(provider, _make_config())
+
+    assert list(envs.keys()) == ["default"]
+    assert len(provider.calls) == 1
+    # Name tag unchanged from the original single-instance behaviour.
+    name_tag = dict(provider.calls[0]["tags"])["Name"]
+    assert name_tag == "inspect_ec2_sandbox_t"
+
+
+@pytest.mark.asyncio
+async def test_sample_init_creates_one_instance_per_name():
+    provider = _make_recording_provider()
+    envs = await _sample_init_with(provider, _make_config(sandbox_names=("a", "b")))
+
+    # First name is the default; order preserved.
+    assert list(envs.keys()) == ["a", "b"]
+    assert envs["a"].instance_id != envs["b"].instance_id
+    assert len(provider.calls) == 2
+    name_tags = sorted(dict(c["tags"])["Name"] for c in provider.calls)
+    assert name_tags == ["inspect_ec2_sandbox_t_a", "inspect_ec2_sandbox_t_b"]
+
+
+@pytest.mark.asyncio
+async def test_sample_init_rolls_back_on_partial_failure():
+    from ec2sandbox._instance_provider import ProvisionedInstance
+
+    provider = mock.MagicMock()
+    provider.terminated = []
+    created_ids = []
+
+    async def create_instance(**kwargs):
+        name = dict(kwargs["tags"])["Name"]
+        if name.endswith("_b"):
+            raise RuntimeError("boom")
+        created_ids.append("i-a")
+        return ProvisionedInstance(
+            instance_id="i-a", region="eu-west-2", s3_bucket="bucket-1"
+        )
+
+    async def terminate_instance(instance_id, region):
+        provider.terminated.append(instance_id)
+
+    provider.create_instance = create_instance
+    provider.terminate_instance = terminate_instance
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _sample_init_with(provider, _make_config(sandbox_names=("a", "b")))
+
+    # The instance that did come up must be terminated, not leaked.
+    assert provider.terminated == created_ids == ["i-a"]
+
+
+def test_sandbox_names_must_be_unique():
+    with pytest.raises(ValueError, match="unique"):
+        _make_config(sandbox_names=("a", "a"))
+
+
+def test_sandbox_names_must_not_be_empty_strings():
+    with pytest.raises(ValueError, match="empty"):
+        _make_config(sandbox_names=("a", ""))


### PR DESCRIPTION
SLOP ALERT

## Summary

Closes #18.

`Ec2SandboxEnvironment.sample_init` previously hardcoded a single environment under the key `"default"`, making exactly one `create_instance` call. There was no config field for the number of instances or their names, so a sample needing **more than one named EC2 sandbox** (e.g. a two-host topology addressed separately via `sandbox("a")` / `sandbox("b")`) couldn't be expressed. The teardown side already iterated over all environments, so the gap was creation-only.

## Changes

- Add an optional `sandbox_names: tuple[str, ...]` field to `Ec2SandboxEnvironmentConfig` (with validation rejecting empty/duplicate names).
- When `sandbox_names` is set, `sample_init` creates one instance per name **concurrently** and returns `{name: env, ...}` with the first name as the default (matching Inspect's "first key is default" rule). When unset, behaviour is unchanged: `{"default": env}`.
- Instances are symmetric (same `instance_type`, `ami_id`, `volume_size`). Per-name `Name` tags get a `_{name}` suffix so they're distinguishable in the console and during cleanup.
- On a partial creation failure, instances that did come up are terminated rather than leaked (since `sample_cleanup` only sees what `sample_init` returns).

Per-name instance-type overrides are left for a follow-up, as suggested in the issue — symmetric instances cover the common case.

## Usage

```python
sandbox=SandboxEnvironmentSpec("ec2", Ec2SandboxEnvironmentConfig.from_settings(
    ...,
    sandbox_names=("victim", "attacker"),
)),
```

`sandbox()` returns `victim`; `sandbox("attacker")` returns the second host.

## Testing

- Unit tests: single-default fallback, one-instance-per-name creation, rollback-on-partial-failure, and the name validators.
- Verified end-to-end against real AWS with a two-host eval (`sandbox_names=("alpha", "beta")`): two distinct instances were created concurrently, `sandbox("alpha")`/`sandbox("beta")` resolved to the correct separate hosts, `sandbox()` defaulted to the first name, and both instances were terminated by `sample_cleanup` (no leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
