### PR TITLE
Load entry points before falling back to the default instance provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- load inspect_ai entry points before falling back to the default provider, so a custom Ec2InstanceProvider registered via a separate entry point is used regardless of import order
 - remove --fail-with-body from curl to support older versions

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -6,6 +6,7 @@ import shlex
 import string
 import sys
 from datetime import datetime
+from importlib.metadata import entry_points
 from logging import getLogger
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Union
@@ -54,6 +55,29 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
 
     _session: ClassVar[boto3.Session | None] = None
 
+    _providers_loaded: ClassVar[bool] = False
+
+    @classmethod
+    def _ensure_providers_loaded(cls) -> None:
+        """Load inspect_ai entry points so a side-effect-registered provider installs.
+
+        inspect_ai loads entry points lazily and skips the sweep once the
+        ``ec2`` sandboxenv is registered, so a provider registered via a
+        separate entry point can be missed depending on import order. We sweep
+        here before falling back to the default provider so resolution doesn't
+        depend on that order.
+        """
+        if cls._providers_loaded:
+            return
+        cls._providers_loaded = True
+        for ep in entry_points(group="inspect_ai"):
+            try:
+                ep.load()
+            except Exception:
+                cls.logger.debug(
+                    "failed loading inspect_ai entry point %s", ep.value, exc_info=True
+                )
+
     @classmethod
     def set_session(cls, session: boto3.Session) -> None:
         """Set the boto3 session used for all AWS operations.
@@ -96,6 +120,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
     ) -> None:
         # If a custom provider supplies a session, adopt it before any
         # samples run so all runtime boto3 calls share the same credentials.
+        cls._ensure_providers_loaded()
         provider = get_ec2_instance_provider()
         provider_session = get_provider_session(provider)
         if provider_session is not None:
@@ -115,6 +140,9 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         environment settings when ``config`` is ``None``).
         """
         registered = get_ec2_instance_provider()
+        if registered is None:
+            cls._ensure_providers_loaded()
+            registered = get_ec2_instance_provider()
         if isinstance(config, Ec2SandboxEnvironmentConfig):
             resolved_config = config
         elif config is None:

--- a/tests/ec2sandboxtest/test_provider_registration.py
+++ b/tests/ec2sandboxtest/test_provider_registration.py
@@ -1,0 +1,65 @@
+"""Provider resolution must not depend on inspect_ai entry-point load order.
+
+inspect_ai loads its entry points lazily and skips the sweep once the ``ec2``
+sandboxenv is registered. A custom Ec2InstanceProvider that registers via its
+own entry point could therefore be missed depending on import order, silently
+falling back to the direct-EC2 default provider. _resolve_provider sweeps the
+entry points before falling back to close that gap.
+"""
+
+from unittest import mock
+
+import ec2sandbox._instance_provider as instance_provider
+from ec2sandbox import set_ec2_instance_provider
+from ec2sandbox._ec2_sandbox_environment import Ec2SandboxEnvironment
+
+
+class _FakeEntryPoint:
+    """Stands in for an inspect_ai entry point that registers a provider."""
+
+    name = "custom-ec2-provider"
+    value = "custompkg.provider"
+
+    def __init__(self, provider):
+        self._provider = provider
+
+    def load(self):
+        set_ec2_instance_provider(self._provider)
+
+
+def test_resolve_provider_sweeps_entry_points_when_none_registered(monkeypatch):
+    # No provider registered yet and the sweep hasn't run.
+    monkeypatch.setattr(instance_provider, "_provider", None)
+    monkeypatch.setattr(Ec2SandboxEnvironment, "_providers_loaded", False)
+
+    custom_provider = mock.MagicMock()
+    monkeypatch.setattr(
+        "ec2sandbox._ec2_sandbox_environment.entry_points",
+        lambda group=None: [_FakeEntryPoint(custom_provider)],
+    )
+
+    provider, _config = Ec2SandboxEnvironment._resolve_provider(None)
+
+    assert provider is custom_provider
+
+
+def test_resolve_provider_skips_sweep_when_already_registered(monkeypatch):
+    already_registered = mock.MagicMock()
+    monkeypatch.setattr(instance_provider, "_provider", already_registered)
+    monkeypatch.setattr(Ec2SandboxEnvironment, "_providers_loaded", False)
+
+    swept = False
+
+    def _tracking_entry_points(group=None):
+        nonlocal swept
+        swept = True
+        return []
+
+    monkeypatch.setattr(
+        "ec2sandbox._ec2_sandbox_environment.entry_points", _tracking_entry_points
+    )
+
+    provider, _config = Ec2SandboxEnvironment._resolve_provider(None)
+
+    assert provider is already_registered
+    assert swept is False


### PR DESCRIPTION
SLOP ALERT

## Summary

Makes instance-provider resolution independent of inspect_ai entry-point load order.

`sample_init` / `task_init` resolve the provider via `get_ec2_instance_provider()`, which only returns a custom provider once that provider's `inspect_ai` entry-point module has been imported. Custom providers register as an import side effect, but inspect_ai loads entry points **lazily** and skips the sweep once the `ec2` sandboxenv type is already registered.

So if anything imports the sandbox module before the first sandbox resolution — e.g. a test module at pytest collection time — the custom provider's entry point is never loaded, and resolution silently falls back to the direct-EC2 `DefaultEc2InstanceProvider`.

This is provider-agnostic: users with no custom provider are unaffected (the sweep finds nothing custom and proceeds to the default, as before).

## Symptom

Running the AWS-touching tests together produced an order-dependent failure: `test_sandbox_self_check.py` imports the sandbox module at collection time (registering `ec2`), which caused `test_inspect_eval` to skip the entry-point sweep and fall back to the default provider — failing where a custom provider was expected. Run alone, `test_inspect_eval` passed. Classic test-order dependence, but the same hole can silently bypass a custom provider in a real eval.

## What changes

- New guarded `Ec2SandboxEnvironment._ensure_providers_loaded()` that loads all `inspect_ai` entry points once.
- `_resolve_provider` calls it when no provider is registered, before falling back to the default; `task_init` calls it before adopting a provider-supplied session.
- Unit tests (no AWS) covering both paths: a provider that registers only via an entry-point sweep is found, and the sweep is skipped when one is already registered.

## Test plan

- [x] `uv run pytest tests/ec2sandboxtest/test_provider_registration.py` — 2 new unit tests pass (no AWS needed).
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy` — clean.
- [x] End-to-end against real EC2: the previously order-dependent `test_eval.py` + `test_sandbox_self_check.py` run now has `test_inspect_eval` passing with no region/provider fallback error. (Remaining self-check timeout errors are unrelated and tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
