### PR TITLE
Expand tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 pythonpath = ["tests"]
 testpaths = ["tests/**/*.py"]
 

--- a/tests/ec2sandboxtest/test_sandbox_self_check.py
+++ b/tests/ec2sandboxtest/test_sandbox_self_check.py
@@ -62,9 +62,6 @@ async def test_self_check(ec2_sandbox_environment) -> None:
         "test_read_file_not_allowed",  # user is root, so this doesn't work
         "test_write_text_file_without_permissions",  # user is root
         "test_write_binary_file_without_permissions",  # user is root
-        "test_exec_timeout",  # cancel_command requires ssm:CancelCommand
-        "test_exec_stdout_is_limited",  # SSM truncates large output before S3 upload
-        "test_exec_stderr_is_limited",  # SSM truncates large output before S3 upload
     ]
 
     return await check_results_of_self_check(ec2_sandbox_environment, known_failures)


### PR DESCRIPTION
Some of the skipped tests are now passing thanks to fixes in our internal EC2 provider