### PR TITLE
Logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- EC2 sandbox logs now appear in the `.eval` transcript at the default log level.
 - `AWS_REGION` ignored for boto compatibility; use `AWS_DEFAULT_REGION` or `INSPECT_EC2_SANDBOX_REGION`
 - custom `Ec2InstanceProvider` must drop the `region` parameter from `find_sandbox_instances()`.
 - `Ec2SandboxEnvironmentConfig.from_settings()` no longer accepts a `session` argument (use Ec2SandboxEnvironment.set_session()).

--- a/README.md
+++ b/README.md
@@ -116,19 +116,20 @@ which raises an error if nothing is configured.
 As an alternative to the above environment variables you can specify the configuration directly in code, e.g
 
 ```python
-sandbox=SandboxEnvironmentSpec("ec2", Ec2SandboxEnvironmentConfig.from_settings(
-    region="eu-west-2",
-    vpc_id="vpc-123456",
-    security_group_id="sg-56781234",
-    s3_bucket="ec2sandboxstack-databucket123-456",
-    instance_profile="Ec2SandboxStack-SandboxInstanceProfile123-456",
-    ami_id="ami-123456",
-    subnet_id="subnet-654321",
-    instance_type="t3a.small",
-    extra_tags=(
-        ("foo", "bar"),
-    )
-)),
+sandbox = SandboxEnvironmentSpec(
+    "ec2",
+    Ec2SandboxEnvironmentConfig.from_settings(
+        region="eu-west-2",
+        vpc_id="vpc-123456",
+        security_group_id="sg-56781234",
+        s3_bucket="ec2sandboxstack-databucket123-456",
+        instance_profile="Ec2SandboxStack-SandboxInstanceProfile123-456",
+        ami_id="ami-123456",
+        subnet_id="subnet-654321",
+        instance_type="t3a.small",
+        extra_tags=(("foo", "bar"),),
+    ),
+)
 ```
 
 See [schema.py](src/ec2sandbox/schema.py) for details.

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -190,12 +190,6 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             (MARKER_TAG_KEY, "true"),
         ]
 
-        cls.logger.debug(
-            "sample_init: provider=%s type=%s ami=%s",
-            type(provider).__name__,
-            resolved.instance_type,
-            resolved.ami_id,
-        )
         # Pass volume_size only when set, so providers that pre-date this
         # parameter keep working unchanged. A caller that sets volume_size
         # against such a provider will get a clear TypeError pointing at
@@ -735,7 +729,7 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
         self._delete_s3_object(file_key)
 
         if result.success:
-            self.logger.info(f"File {file} written successfully to EC2 instance.")
+            self.logger.debug(f"File {file} written successfully to EC2 instance.")
 
         if not result.success:
             if "is a directory" in result.stderr.casefold():

--- a/src/ec2sandbox/_ec2_sandbox_environment.py
+++ b/src/ec2sandbox/_ec2_sandbox_environment.py
@@ -7,7 +7,7 @@ import string
 import sys
 from datetime import datetime
 from importlib.metadata import entry_points
-from logging import getLogger
+from logging import INFO, NOTSET, getLogger
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Set, Union
 
@@ -44,6 +44,14 @@ __all__ = ["Ec2SandboxEnvironment", "Ec2SandboxEnvironmentConfig", "MARKER_TAG_K
 
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 3600
 WAITER_DELAY_SECONDS = 1
+
+# Inspect only lowers its own package loggers below the root WARNING default, so a
+# third-party provider's INFO never reaches the .eval transcript. As an Inspect
+# extension we opt our own logger in, taking the root's level where it is already
+# lower so --log-level debug/trace still reaches us. Guarded on NOTSET so a level
+# set before this import is not clobbered.
+if getLogger("ec2sandbox").level == NOTSET:
+    getLogger("ec2sandbox").setLevel(min(INFO, getLogger().getEffectiveLevel()))
 
 
 @sandboxenv(name="ec2")
@@ -201,8 +209,11 @@ class Ec2SandboxEnvironment(SandboxEnvironment):
             tags=tags,
             **extra,
         )
-        cls.logger.debug(
-            "sample_init: provider returned id=%s region=%s",
+        cls.logger.info(
+            "sample_init: provider=%s type=%s ami=%s id=%s region=%s",
+            type(provider).__name__,
+            resolved.instance_type,
+            resolved.ami_id,
             result.instance_id,
             result.region,
         )

--- a/tests/ec2sandboxtest/test_logging.py
+++ b/tests/ec2sandboxtest/test_logging.py
@@ -7,7 +7,6 @@ are dropped before Inspect's handler ever sees them.
 
 from __future__ import annotations
 
-import importlib
 import logging
 from unittest import mock
 
@@ -21,45 +20,9 @@ PACKAGE_LOGGER = "ec2sandbox"
 MODULE_LOGGER = "ec2sandbox._ec2_sandbox_environment"
 
 
-@pytest.fixture
-def _restore_levels():
-    package = logging.getLogger(PACKAGE_LOGGER)
-    root = logging.getLogger()
-    package_level, root_level = package.level, root.level
-    yield
-    package.setLevel(package_level)
-    root.setLevel(root_level)
-
-
-def _repromote(root_level: int, package_level: int = logging.NOTSET) -> logging.Logger:
-    """Re-run the module's import-time promotion against the given levels."""
-    logging.getLogger(PACKAGE_LOGGER).setLevel(package_level)
-    logging.getLogger().setLevel(root_level)
-    importlib.reload(_ec2_sandbox_environment)
-    return logging.getLogger(PACKAGE_LOGGER)
-
-
 def test_package_logger_enabled_for_info() -> None:
     """INFO is enabled at the default log level, so the .eval captures it."""
     assert logging.getLogger(PACKAGE_LOGGER).isEnabledFor(logging.INFO)
-
-
-def test_package_logger_follows_lower_root_level(_restore_levels: None) -> None:
-    """--log-level debug still reaches us; a flat setLevel(INFO) would not.
-
-    Asserts the level rather than isEnabledFor, which a logger left at NOTSET
-    would satisfy by inheriting the root level.
-    """
-    assert _repromote(logging.DEBUG).level == logging.DEBUG
-
-
-def test_package_logger_respects_preset_level(_restore_levels: None) -> None:
-    """A level set before import is not clobbered.
-
-    Root sits below the preset level, so an unguarded promotion would lower it.
-    """
-    promoted = _repromote(logging.DEBUG, package_level=logging.ERROR)
-    assert promoted.level == logging.ERROR
 
 
 async def test_sample_init_logs_instance_at_info(

--- a/tests/ec2sandboxtest/test_logging.py
+++ b/tests/ec2sandboxtest/test_logging.py
@@ -1,0 +1,109 @@
+"""Tests that the package logger is opted in so its records reach the .eval.
+
+Inspect leaves third-party package loggers at the root WARNING default, so
+without the promotion in _ec2_sandbox_environment the sandbox's INFO records
+are dropped before Inspect's handler ever sees them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from unittest import mock
+
+import pytest
+
+from ec2sandbox import _ec2_sandbox_environment
+from ec2sandbox._instance_provider import ProvisionedInstance
+from ec2sandbox.schema import Ec2SandboxEnvironmentConfig
+
+PACKAGE_LOGGER = "ec2sandbox"
+MODULE_LOGGER = "ec2sandbox._ec2_sandbox_environment"
+
+
+@pytest.fixture
+def _restore_levels():
+    package = logging.getLogger(PACKAGE_LOGGER)
+    root = logging.getLogger()
+    package_level, root_level = package.level, root.level
+    yield
+    package.setLevel(package_level)
+    root.setLevel(root_level)
+
+
+def _repromote(root_level: int, package_level: int = logging.NOTSET) -> logging.Logger:
+    """Re-run the module's import-time promotion against the given levels."""
+    logging.getLogger(PACKAGE_LOGGER).setLevel(package_level)
+    logging.getLogger().setLevel(root_level)
+    importlib.reload(_ec2_sandbox_environment)
+    return logging.getLogger(PACKAGE_LOGGER)
+
+
+def test_package_logger_enabled_for_info() -> None:
+    """INFO is enabled at the default log level, so the .eval captures it."""
+    assert logging.getLogger(PACKAGE_LOGGER).isEnabledFor(logging.INFO)
+
+
+def test_package_logger_follows_lower_root_level(_restore_levels: None) -> None:
+    """--log-level debug still reaches us; a flat setLevel(INFO) would not.
+
+    Asserts the level rather than isEnabledFor, which a logger left at NOTSET
+    would satisfy by inheriting the root level.
+    """
+    assert _repromote(logging.DEBUG).level == logging.DEBUG
+
+
+def test_package_logger_respects_preset_level(_restore_levels: None) -> None:
+    """A level set before import is not clobbered.
+
+    Root sits below the preset level, so an unguarded promotion would lower it.
+    """
+    promoted = _repromote(logging.DEBUG, package_level=logging.ERROR)
+    assert promoted.level == logging.ERROR
+
+
+async def test_sample_init_logs_instance_at_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """sample_init records which instance ran the sample, and on what."""
+    fake_provider = mock.MagicMock()
+
+    async def create_instance(**kwargs):
+        return ProvisionedInstance(
+            instance_id="i-log",
+            region="eu-west-2",
+            s3_bucket="bucket-1",
+        )
+
+    fake_provider.create_instance = create_instance
+    sandbox = _ec2_sandbox_environment.Ec2SandboxEnvironment
+
+    with (
+        mock.patch(
+            "ec2sandbox._ec2_sandbox_environment.get_ec2_instance_provider",
+            return_value=fake_provider,
+        ),
+        caplog.at_level(logging.INFO, logger=MODULE_LOGGER),
+    ):
+        try:
+            await sandbox.sample_init(
+                task_name="logging-task",
+                config=Ec2SandboxEnvironmentConfig(
+                    instance_type="t3a.micro", ami_id="ami-123"
+                ),
+                metadata={},
+            )
+        finally:
+            sandbox._tracked_instances.clear()
+
+    records = [r for r in caplog.records if r.message.startswith("sample_init:")]
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+    for fragment in (
+        "provider=MagicMock",
+        "type=t3a.micro",
+        "ami=ami-123",
+        "id=i-log",
+        "region=eu-west-2",
+    ):
+        assert fragment in records[0].message


### PR DESCRIPTION
Closes #38

Inspect's `init_logger` raises only its own package logger. `ec2sandbox` stays at `NOTSET`, inherits root's `WARNING`, and `INFO` records are dropped at the logger. This PR promotes the `ec2sandbox` logger to `min(INFO, root's effective level)`, this does not affect terminal output but does enable logs at `INFO` and above to be included in Inspect's `.eval` file. The min addition is so `--log-level debug` still works, a flat `setLevel(INFO)` would kill `DEBUG` and `TRACE` at the logger. `sample_init` now logs at `INFO` with the provider, instance type and AMI, so the `.eval` records which instance ran each sample.

The issue for this said the promotion would happen within `__init__.py`, this was Claude's suggestion as `__init__.py` runs on any import of `ec2sandbox` and would cover a custom provider used without the environment module. However that is a fringe issue as it stands, so I followed proxmox convention and declared it in `_ec2_sandbox_environment.py`, to keep consistency between repos.

There are 4 unit tests as part of this PR, all of them pass. However, it is worth noting that this has NOT been run against real AWS infrastructure for cost related reasons, potentially worth doing before accepting the PR, but the risk is low as there won't be much logging level difference between mocked and real infra.