### PR TITLE
Ask contributors to verify runtime-behaviour claims against real AWS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
 # Repo guidance for coding agents
 
+Read [CONTRIBUTING.md](CONTRIBUTING.md) too — dev setup, architecture, test invocation
+and the reasoning behind the rules below are there.
+
+## Before you open a PR
+
+1. Does your change assert something about runtime behaviour — what EC2, SSM or S3
+   actually does? Run it against real AWS and paste the output. Reading upstream source
+   is not evidence, and neither is a test that patches boto3, however green.
+2. Show it failing without your change and passing with it. If you can't, say so
+   explicitly in the PR description.
+3. If you can't run against real AWS, don't open the PR. Open an issue with your
+   reasoning and stop.
+4. Report what you actually ran, verbatim, including which tests were skipped. Never
+   describe a run you didn't perform.
+5. Note the tooling you used. If you ran review passes over your own change, say which
+   model and what they found.
+
 ## Changelog (`CHANGELOG.md`)
 
 New work goes under the `## Unreleased` heading. Each entry is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,36 @@ in our [Inspect
 Community](https://join.slack.com/t/inspectcommunity/shared_invite/zt-2w9eaeusj-4Hu~IBHx2aORsKz~njuz4g)
 Slack workspace.
 
+## Before you open a PR
+
+This provider is a thin layer over infrastructure we don't control — the EC2, SSM and S3
+APIs. Most bugs in it are claims about what that infrastructure does at runtime, and
+those are cheap to get wrong from reading documentation or upstream source.
+
+If your change asserts a runtime behaviour, we need the observation, not the derivation.
+
+- **Run it against real AWS and paste what you saw.** The `req_aws` marker identifies
+  the tests that need credentials. A test without that marker is not evidence about
+  runtime behaviour, however green it is.
+- **Show the negative control.** Give the result with your change and without it. If you
+  can't produce a run that fails on `main` and passes on your branch, say so and explain
+  why.
+- **If you can't run it, open an issue rather than a PR.** Reasoning, upstream source
+  links and a proposed patch are all welcome in an issue. A confidently argued wrong
+  premise costs more than no PR at all, because it has to be disproved before it can be
+  declined.
+
+The trap specific to this repo is that nothing reaches the sandbox VM directly: control
+goes through the EC2 and SSM APIs, data through S3 (see Architecture below). Patching
+boto3 establishes nothing about how SSM actually behaves — its timing, its truncation
+limits, the shape of its errors. Instance creation is also pluggable
+(`Ec2InstanceProvider`), so a run against one provider says little about another; say
+which one you ran.
+
+A sufficient experiment looks like: baseline without the change, the behaviour with it,
+then baseline again to show the effect went away — several attempts per phase, plus a
+positive control proving the test could have observed a difference if there were one.
+
 ## Getting started
 
 This project uses [uv](https://github.com/astral-sh/uv) for Python packaging.
@@ -16,13 +46,12 @@ Run this beforehand:
 uv sync
 ```
 
-You then can either source the venv with
+The commands below are written as `uv run ...`, which works whether or not the venv is
+activated. Drop the prefix if you'd rather activate it:
 
 ```
 source .venv/bin/activate
 ```
-
-or prefix your pytest (etc.) commands with `uv run ...`
 
 ## Architecture
 
@@ -43,12 +72,20 @@ flows through the AWS control plane (EC2 + SSM) and all data flows through S3.
 
 ![Architecture](docs/architecture.drawio.png)
 
-## Tests
+## Testing
 
-Run the tests with `uv run pytest`.
+Run the tests with:
+
+```bash
+uv run pytest
+```
 
 For most of the tests you will need AWS credentials to be available to the boto
-python library.
+python library. To skip those:
+
+```bash
+uv run pytest -m "not req_aws"
+```
 
 ## Linting & Formatting
 
@@ -66,5 +103,38 @@ uv run ruff format .
 manually:
 
 ```bash
-mypy
+uv run mypy
 ```
+
+## Changelog
+
+If appropriate, add an entry under the `## Unreleased` heading in `CHANGELOG.md` when
+submitting a PR. Create that heading if the last release consumed it.
+
+Entries under a dated release heading are published history — don't add to or edit
+them. In particular, if a release is cut after you branch, a stale branch can silently
+land your entry in the just-released section (the release commit renames `##
+Unreleased` to the dated heading, so your diff still applies): after rebasing onto
+`main`, check your entry still sits under `## Unreleased`.
+
+## Conventions
+
+### Package Structure and API Visibility
+
+The Python packages, modules and members follow a similar API visibility naming
+convention to that used in the [inspect_ai](https://inspect.aisi.org.uk/) package.
+
+Public API members (e.g. classes, functions, constants) are exported in the package's
+`__init__.py` file. Members are exported rather than modules (i.e. .py files) to avoid
+all of the module's imports also being implicitly exported.
+
+Module-private members are prefixed with an underscore `_`. These members are not
+intended for use outside of the module in which they are defined (except in tests).
+
+Class-private members are prefixed with an underscore `_`. These members are not
+intended for use outside of the class in which they are defined (except in tests). We
+don't use double underscores `__`  which is consistent with [Google's Python style
+guide](https://google.github.io/styleguide/pyguide.html).
+
+Non-public modules (i.e. .py files) are prefixed with an underscore `_` (unless a parent
+package is already prefixed with an underscore).


### PR DESCRIPTION
Document the evidence bar for a PR that asserts runtime behaviour: an observation against
real AWS, not a derivation from documentation or upstream source. This provider is a thin
layer over the EC2, SSM and S3 APIs, so most bugs in it are claims about what that
infrastructure does at runtime — and a test that patches boto3 establishes nothing about
how SSM actually behaves. Instance creation is pluggable too, so a run against one
`Ec2InstanceProvider` says little about another; the text asks contributors to say which
one they ran.

The rule goes in CONTRIBUTING.md with its rationale (a human reasoning from upstream source
without testing makes the same error) and in AGENTS.md as a pre-PR checklist, because agents
reliably read that file and often don't read CONTRIBUTING.md. Companion PRs do the same for
the k8s and proxmox providers: UKGovernmentBEIS/inspect_k8s_sandbox#246 and
UKGovernmentBEIS/inspect_proxmox_sandbox#114.

Also aligns this guide with those two while I'm here: `Testing` rather than `Tests`, the
`-m "not req_aws"` invocation for skipping the AWS tests, `uv run mypy` rather than a bare
`mypy` that only works with the venv activated, and the changelog and API-visibility
conventions that k8s already documents.

Docs only. Verified the commands the new text quotes: `uv run ruff check .`,
`uv run ruff format --check .`, `uv run mypy`, and `uv run pytest -m "not req_aws"`
(collects 35, deselects 12).

### Agent review
- Reviewer: none. Author is Claude Opus 5 (Claude Code) working interactively with me; no
  separate review pass over this docs change.
