### PR TITLE
Prepare first real PyPI release (0.1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .vscode/
 .ruff_cache
 cdk.out
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026-08-20 0.1.1
 
 - EC2 sandbox logs now appear in the `.eval` transcript at the default log level.
 - `AWS_REGION` ignored for boto compatibility; use `AWS_DEFAULT_REGION` or `INSPECT_EC2_SANDBOX_REGION`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,4 @@
 
 ## 2026-08-20 0.1.1
 
-- EC2 sandbox logs now appear in the `.eval` transcript at the default log level.
-- `AWS_REGION` ignored for boto compatibility; use `AWS_DEFAULT_REGION` or `INSPECT_EC2_SANDBOX_REGION`
-- custom `Ec2InstanceProvider` must drop the `region` parameter from `find_sandbox_instances()`.
-- `Ec2SandboxEnvironmentConfig.from_settings()` no longer accepts a `session` argument (use Ec2SandboxEnvironment.set_session()).
-- Custom `Ec2InstanceProvider`s are now resolved regardless of entry-point import order.
-- Interrupted samples (Ctrl-C, failed setup script) no longer leak EC2 instances.
-- Failed instance creation (cloud-init / SSM timeout) no longer leaks the instance.
-- remove --fail-with-body from curl to support older versions
+- First release published to PyPI. For earlier changes, see the git history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,19 @@ manually:
 ```bash
 mypy
 ```
+
+## Releasing
+
+Releases are published manually using uv's standard
+[build](https://docs.astral.sh/uv/guides/package/#building-your-package) and
+[publish](https://docs.astral.sh/uv/guides/package/#publishing-your-package) flow —
+this guide does not duplicate those steps.
+
+The repo-specific parts are:
+
+- Bump `version` in `pyproject.toml` and run `uv lock` to update `uv.lock`.
+- Replace the `## Unreleased` heading in `CHANGELOG.md` with `## <YYYY-MM-DD> <version>`
+  (see existing entries for the format).
+- After merging, tag the release commit `vX.Y.Z` and push the tag.
+- Before publishing, check the sdist and wheel contents (`tar -tzf` / `unzip -l` on
+  `dist/*`) — in particular that `infra/` hasn't crept into the sdist.

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ as sandboxes, running within AWS EC2.
 Add this using [uv](https://github.com/astral-sh/uv)
 
 ```
-uv add git+ssh://git@github.com/UKGovernmentBEIS/inspect_ec2_sandbox.git
-``` 
-or in [Poetry](https://python-poetry.org/),
+uv add inspect-ec2-sandbox
+```
+or with pip,
 
 ```
-poetry add git+ssh://git@github.com/UKGovernmentBEIS/inspect_ec2_sandbox.git
+pip install inspect-ec2-sandbox
 ```
 
 
 ## AWS Infrastructure
 
-This plugin depends on certain infrastructure existing already. See the [infra docs](infra/README.md) for a
+This plugin depends on certain infrastructure existing already. See the [infra docs](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/infra/README.md) for a
 reference CDK stack which you can use to create it. If you use the reference stack, you can skip reading
 the rest of this section.
 
@@ -132,7 +132,7 @@ sandbox = SandboxEnvironmentSpec(
 )
 ```
 
-See [schema.py](src/ec2sandbox/schema.py) for details.
+See [schema.py](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/src/ec2sandbox/schema.py) for details.
 
 ## Compatibility with existing Inspect evals
 
@@ -143,7 +143,7 @@ It is not a drop-in replacement; passing `--sandbox ec2` is unlikely to work for
 
 ## Sample evaluation
 
-You can look at an existing [sample eval](src/ec2sandbox/examples/where_am_i.py) for how to get started.
+You can look at an existing [sample eval](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/src/ec2sandbox/examples/where_am_i.py) for how to get started.
 
 A more complex eval is [Sandbox Escape Bench](https://github.com/UKGovernmentBEIS/sandbox_escape_bench), where this EC2 sandbox is used as an outer sandbox and the agent is tasked with escaping an inner sandbox, generally Docker or Kubernetes.
 
@@ -163,4 +163,4 @@ For the EC2 sandbox specifically, beware that the IAM role used by the sandbox E
 
 ## Developing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install inspect-ec2-sandbox
 
 ## AWS Infrastructure
 
-This plugin depends on certain infrastructure existing already. See the [infra docs](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/infra/README.md) for a
+This plugin depends on certain infrastructure existing already. See the [infra docs](infra/README.md) for a
 reference CDK stack which you can use to create it. If you use the reference stack, you can skip reading
 the rest of this section.
 
@@ -132,7 +132,7 @@ sandbox = SandboxEnvironmentSpec(
 )
 ```
 
-See [schema.py](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/src/ec2sandbox/schema.py) for details.
+See [schema.py](src/ec2sandbox/schema.py) for details.
 
 ## Compatibility with existing Inspect evals
 
@@ -143,7 +143,7 @@ It is not a drop-in replacement; passing `--sandbox ec2` is unlikely to work for
 
 ## Sample evaluation
 
-You can look at an existing [sample eval](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/src/ec2sandbox/examples/where_am_i.py) for how to get started.
+You can look at an existing [sample eval](src/ec2sandbox/examples/where_am_i.py) for how to get started.
 
 A more complex eval is [Sandbox Escape Bench](https://github.com/UKGovernmentBEIS/sandbox_escape_bench), where this EC2 sandbox is used as an outer sandbox and the agent is tasked with escaping an inner sandbox, generally Docker or Kubernetes.
 
@@ -163,4 +163,4 @@ For the EC2 sandbox specifically, beware that the IAM role used by the sandbox E
 
 ## Developing
 
-See [CONTRIBUTING.md](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/CONTRIBUTING.md)
+See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "inspect-ec2-sandbox"
 version = "0.1.1"
 description = "An EC2 Sandbox Environment for Inspect"
-readme = "README.md"
+dynamic = ["readme"]
 license = "MIT"
 authors = [
     {name = "UK AI Security Institute"}
@@ -40,8 +40,21 @@ markers = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
+
+# The PyPI page renders README.md without a base URL, so repo-relative links 404
+# there. Rewrite them to GitHub URLs at build time only, keeping the links in the
+# repo relative (working in editors and independent of the git host).
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\]\((?!https?://|#|mailto:)([^)]+)\)'
+replacement = '](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/\1)'
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ec2sandbox"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "inspect-ec2-sandbox"
 version = "0.1.1"
 description = "An EC2 Sandbox Environment for Inspect"
 readme = "README.md"
+license = "MIT"
 authors = [
     {name = "UK AI Security Institute"}
 ]
@@ -19,6 +20,10 @@ dependencies = [
     "websocket-client>=1.8.0",
     "pydantic-settings>=2.14.2",
 ]
+
+[project.urls]
+Repository = "https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox"
+Changelog = "https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox/blob/main/CHANGELOG.md"
 
 [project.entry-points."inspect_ai"]
 "ec2-sandbox" = "ec2sandbox._ec2_sandbox_environment"
@@ -41,8 +46,10 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/ec2sandbox"]
 
-[tool.hatch.metadata]
-allow-direct-references = true
+# Keep infra/ (contains environment-specific CDK context), tests/ and uv.lock
+# out of the published sdist
+[tool.hatch.build.targets.sdist]
+only-include = ["src", "README.md", "CHANGELOG.md", "LICENSE"]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
**TL;DR:** Prepares the first real PyPI release (0.1.1), replacing the 0.0.1 placeholder. Same process as inspect_k8s_sandbox: manual `uv build` / `uv publish`, `vX.Y.Z` tag, dated changelog heading — now documented in CONTRIBUTING.md.

<details><summary>Details</summary>

Without the new sdist allowlist, hatchling's default sdist ships `infra/` (including the tracked `cdk.context.json` and `.env.test`), `tests/` and the 664 KB `uv.lock`. Verified the built artifacts: sdist contains only `src/` + README/CHANGELOG/LICENSE, wheel only `ec2sandbox/**` incl. `py.typed`, `twine check` passes, and the wheel METADATA carries the MIT license expression and project URLs.

The pre-release `## Unreleased` bullets are collapsed to a "first release" one-liner — earlier changes live in git history.

Publishing needs owner/maintainer rights on the existing PyPI project (whoever uploaded the 2025-09-01 placeholder has them).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
